### PR TITLE
Expose step transport processes to both UI and API.

### DIFF
--- a/src/Data/LifeCycle.elm
+++ b/src/Data/LifeCycle.elm
@@ -69,28 +69,17 @@ fromQuery db =
 
 init : Inputs -> LifeCycle
 init inputs =
-    initSteps inputs |> update inputs
-
-
-initSteps : Inputs -> LifeCycle
-initSteps inputs =
     inputs.countries
         |> List.map2
-            (\( label, editable ) -> Step.create label editable)
+            (\( label, editable ) country -> Step.create label editable country)
             [ ( Step.MaterialAndSpinning, False )
             , ( Step.WeavingKnitting, True )
             , ( Step.Ennoblement, True )
             , ( Step.Making, True )
             , ( Step.Distribution, False )
             ]
+        |> List.map (Step.updateFromInputs inputs)
         |> Array.fromList
-
-
-update : Inputs -> LifeCycle -> LifeCycle
-update inputs lifeCycle =
-    lifeCycle
-        |> Array.indexedMap
-            (\index -> Step.update inputs (Array.get (index + 1) lifeCycle))
 
 
 updateStep : Step.Label -> (Step -> Step) -> LifeCycle -> LifeCycle

--- a/src/Views/Step.elm
+++ b/src/Views/Step.elm
@@ -226,17 +226,15 @@ detailedView ({ product, index, next, current } as config) =
                     Nothing ->
                         text ""
                 ]
-            , div [ class "card-body py-2 text-muted" ]
-                [ case current.label of
-                    Step.Ennoblement ->
-                        dyeingWeightingField config
+            , case current.label of
+                Step.Ennoblement ->
+                    div [ class "card-body py-2 text-muted" ] [ dyeingWeightingField config ]
 
-                    Step.Making ->
-                        airTransportRatioField config
+                Step.Making ->
+                    div [ class "card-body py-2 text-muted" ] [ airTransportRatioField config ]
 
-                    _ ->
-                        text ""
-                ]
+                _ ->
+                    text ""
             ]
         , div
             [ class "card text-center" ]
@@ -273,11 +271,20 @@ detailedView ({ product, index, next, current } as config) =
                   else
                     text ""
                 , li [ class "list-group-item text-muted" ]
-                    [ current.transport |> TransportView.view { fullWidth = True } ]
-                , li [ class "list-group-item text-muted d-flex justify-content-center align-items-center" ]
-                    [ strong [] [ text <| transportLabel ++ "\u{00A0}:\u{00A0}" ]
-                    , Format.kgCo2 3 current.transport.co2
-                    , inlineDocumentationLink config Gitbook.Transport
+                    [ current.transport
+                        |> TransportView.view
+                            { fullWidth = True
+                            , airTransportLabel = current.processInfo.airTransport |> Maybe.map .name
+                            , seaTransportLabel = current.processInfo.seaTransport |> Maybe.map .name
+                            , roadTransportLabel = current.processInfo.roadTransport |> Maybe.map .name
+                            }
+                    ]
+                , li [ class "list-group-item text-muted" ]
+                    [ div [ class "d-flex justify-content-center align-items-center" ]
+                        [ strong [] [ text <| transportLabel ++ "\u{00A0}:\u{00A0}" ]
+                        , Format.kgCo2 3 current.transport.co2
+                        , inlineDocumentationLink config Gitbook.Transport
+                        ]
                     ]
                 ]
             ]

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -49,7 +49,12 @@ summaryView { session, reusable } ({ inputs, lifeCycle } as simulator) =
                 |> ul [ class "Chevrons" ]
             , lifeCycle
                 |> LifeCycle.computeTotalTransports
-                |> TransportView.view { fullWidth = False }
+                |> TransportView.view
+                    { fullWidth = False
+                    , airTransportLabel = Just "Transport aérien total"
+                    , seaTransportLabel = Just "Transport maritime total"
+                    , roadTransportLabel = Just "Transport routier total"
+                    }
             ]
         , details [ class "card-body p-2 border-bottom" ]
             [ summary [ class "text-muted fs-7" ] [ text "Détails des postes" ]

--- a/src/Views/Transport.elm
+++ b/src/Views/Transport.elm
@@ -8,11 +8,15 @@ import Views.Icon as Icon
 
 
 type alias Config =
-    { fullWidth : Bool }
+    { fullWidth : Bool
+    , airTransportLabel : Maybe String
+    , seaTransportLabel : Maybe String
+    , roadTransportLabel : Maybe String
+    }
 
 
 view : Config -> Transport -> Html msg
-view { fullWidth } { road, air, sea } =
+view { fullWidth, airTransportLabel, seaTransportLabel, roadTransportLabel } { road, air, sea } =
     div
         [ classList
             [ ( "d-flex fs-7", True )
@@ -20,16 +24,16 @@ view { fullWidth } { road, air, sea } =
             , ( "justify-content-center", not fullWidth )
             ]
         ]
-        [ span [ class "mx-2" ]
-            [ span [ class "me-1" ] [ Icon.plane ]
+        [ span [ class "mx-2", airTransportLabel |> Maybe.withDefault "" |> title ]
+            [ span [ class "me-1", style "cursor" "help" ] [ Icon.plane ]
             , Format.km air
             ]
-        , span [ class "mx-2" ]
-            [ span [ class "me-1" ] [ Icon.boat ]
+        , span [ class "mx-2", seaTransportLabel |> Maybe.withDefault "" |> title ]
+            [ span [ class "me-1", style "cursor" "help" ] [ Icon.boat ]
             , Format.km sea
             ]
-        , span [ class "mx-2" ]
-            [ span [ class "me-1" ] [ Icon.bus ]
+        , span [ class "mx-2", roadTransportLabel |> Maybe.withDefault "" |> title ]
+            [ span [ class "me-1", style "cursor" "help" ] [ Icon.bus ]
             , Format.km road
             ]
         ]


### PR DESCRIPTION
[User Story](https://www.notion.so/fd0068a7db8348c584cd53a3eea399f2?v=af2332265058414da4bd3aa4d381ed5f&p=e78a94318c4743c4a84a532a692506a6)

Note: the production API server doesn't reflect this patch, though you can inspect the generated `data/dump-presets.json` which should be available online [here](https://wikicarbone.beta.gouv.fr/branches/attach-step-transport-process-info/data/dump-presets.json) once the PR is built.