### PR TITLE
All impacts at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start:dev": "npm run build:init && concurrently -n \"watch,parcel\" -c \"blue,green\" -k \"npm run start:filewatch\" \"npm run start:parcel\"",
     "start": "PARCEL_ELM_NO_DEBUG=1 npm run start:dev",
     "test:prepare": "node tests/prepare.js",
+    "test:all": "npm test && npm run server:test",
     "test": "npm run test:prepare && elm-test"
   },
   "devDependencies": {

--- a/src/Data/Db.elm
+++ b/src/Data/Db.elm
@@ -10,8 +10,8 @@ import Json.Decode as Decode exposing (Decoder)
 
 
 type alias Db =
-    { processes : List Process
-    , impacts : List Impact.Definition
+    { impacts : List Impact.Definition
+    , processes : List Process
     , countries : List Country
     , materials : List Material
     , products : List Product
@@ -21,8 +21,8 @@ type alias Db =
 
 empty : Db
 empty =
-    { processes = []
-    , impacts = []
+    { impacts = []
+    , processes = []
     , countries = []
     , materials = []
     , products = []
@@ -38,13 +38,16 @@ buildFromJson json =
 
 decode : Decoder Db
 decode =
-    Decode.field "processes" Process.decodeList
+    Decode.field "impacts" Impact.decodeList
         |> Decode.andThen
-            (\processes ->
-                Decode.map5 (Db processes)
-                    (Decode.field "impacts" Impact.decodeList)
-                    (Decode.field "countries" (Country.decodeList processes))
-                    (Decode.field "materials" (Material.decodeList processes))
-                    (Decode.field "products" (Product.decodeList processes))
-                    (Decode.field "transports" Transport.decodeDistances)
+            (\impacts ->
+                Decode.field "processes" (Process.decodeList impacts)
+                    |> Decode.andThen
+                        (\processes ->
+                            Decode.map4 (Db impacts processes)
+                                (Decode.field "countries" (Country.decodeList processes))
+                                (Decode.field "materials" (Material.decodeList processes))
+                                (Decode.field "products" (Product.decodeList processes))
+                                (Decode.field "transports" Transport.decodeDistances)
+                        )
             )

--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -127,9 +127,18 @@ updateImpact trigram value =
     AnyDict.update trigram (Maybe.map (always value))
 
 
-decodeImpacts : Decoder Impacts
-decodeImpacts =
-    AnyDict.decode (\str _ -> trg str) toString Unit.decodeImpact
+decodeImpacts : List Definition -> Decoder Impacts
+decodeImpacts definitions =
+    AnyDict.decode_
+        (\str _ ->
+            if definitions |> List.map .trigram |> List.member (trg str) then
+                Ok (trg str)
+
+            else
+                Err <| "Trigramme d'impact inconnu: " ++ str
+        )
+        toString
+        Unit.decodeImpact
 
 
 encodeImpacts : Impacts -> Encode.Value

--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -118,6 +118,11 @@ getImpact trigram =
         >> Maybe.withDefault Quantity.zero
 
 
+grabImpactFloat : Trigram -> { a | impacts : Impacts } -> Float
+grabImpactFloat trigram { impacts } =
+    impacts |> getImpact trigram |> Unit.impactToFloat
+
+
 filterImpacts : (Trigram -> Unit.Impact -> Bool) -> Impacts -> Impacts
 filterImpacts fn =
     AnyDict.filter fn

--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -117,6 +117,11 @@ getImpact trigram =
         >> Maybe.withDefault Quantity.zero
 
 
+mapImpacts : (Trigram -> Unit.Impact -> Unit.Impact) -> Impacts -> Impacts
+mapImpacts fn =
+    AnyDict.map fn
+
+
 updateImpact : Trigram -> Unit.Impact -> Impacts -> Impacts
 updateImpact trigram value =
     AnyDict.update trigram (Maybe.map (always value))

--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -6,6 +6,7 @@ import Dict.Any as AnyDict exposing (AnyDict)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
 import Quantity exposing (Quantity(..))
+import Url.Parser as Parser exposing (Parser)
 
 
 
@@ -117,6 +118,11 @@ getImpact trigram =
         >> Maybe.withDefault Quantity.zero
 
 
+filterImpacts : (Trigram -> Unit.Impact -> Bool) -> Impacts -> Impacts
+filterImpacts fn =
+    AnyDict.filter fn
+
+
 mapImpacts : (Trigram -> Unit.Impact -> Unit.Impact) -> Impacts -> Impacts
 mapImpacts fn =
     AnyDict.map fn
@@ -144,3 +150,23 @@ decodeImpacts definitions =
 encodeImpacts : Impacts -> Encode.Value
 encodeImpacts =
     AnyDict.encode toString Unit.encodeImpact
+
+
+
+-- Parser
+
+
+parseTrigram : Parser (Trigram -> a) a
+parseTrigram =
+    let
+        trigrams =
+            "acd,ozd,cch,ccb,ccf,ccl,fwe,swe,tre,pco,pma,ior,fru,mru,ldu"
+                |> String.split ","
+    in
+    Parser.custom "TRIGRAM" <|
+        \trigram ->
+            if List.member trigram trigrams then
+                Just (trg trigram)
+
+            else
+                Just defaultTrigram

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -16,8 +16,7 @@ import Mass exposing (Mass)
 
 
 type alias Inputs =
-    { impact : Impact.Definition
-    , mass : Mass
+    { mass : Mass
     , material : Material
     , product : Product
     , countries : List Country
@@ -53,15 +52,13 @@ fromQuery : Db -> Query -> Result String Inputs
 fromQuery db query =
     let
         lookups =
-            { impact = db.impacts |> Impact.getDefinition query.impact
-            , material = db.materials |> Material.findByUuid query.material
+            { material = db.materials |> Material.findByUuid query.material
             , product = db.products |> Product.findById query.product
             , countries = db.countries |> Country.findByCodes query.countries
             }
 
-        build impact_ material_ product_ countries_ =
-            { impact = impact_
-            , mass = query.mass
+        build material_ product_ countries_ =
+            { mass = query.mass
             , material = material_
             , product = product_
             , countries = countries_
@@ -71,16 +68,15 @@ fromQuery db query =
             , customCountryMixes = query.customCountryMixes
             }
     in
-    Result.map4 build
-        lookups.impact
+    Result.map3 build
         lookups.material
         lookups.product
         lookups.countries
 
 
-toQuery : Inputs -> Query
-toQuery inputs =
-    { impact = inputs.impact.trigram
+toQuery : Impact.Trigram -> Inputs -> Query
+toQuery trigram inputs =
+    { impact = trigram
     , mass = inputs.mass
     , material = inputs.material.uuid
     , product = inputs.product.id
@@ -364,8 +360,7 @@ presets trigram =
 encode : Inputs -> Encode.Value
 encode inputs =
     Encode.object
-        [ ( "impact", Impact.encodeDefinition inputs.impact )
-        , ( "mass", Encode.float (Mass.inKilograms inputs.mass) )
+        [ ( "mass", Encode.float (Mass.inKilograms inputs.mass) )
         , ( "material", Material.encode inputs.material )
         , ( "product", Product.encode inputs.product )
         , ( "countries", Encode.list Country.encode inputs.countries )

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -12,6 +12,7 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
 import Mass exposing (Mass)
+import Url.Parser as Parser exposing (Parser)
 
 
 type alias Inputs =
@@ -398,3 +399,15 @@ b64decode =
 b64encode : Query -> String
 b64encode =
     encodeQuery >> Encode.encode 0 >> Base64.encode
+
+
+
+-- Parser
+
+
+parseBase64Query : Parser (Maybe Query -> a) a
+parseBase64Query =
+    Parser.custom "QUERY" <|
+        b64decode
+            >> Result.toMaybe
+            >> Just

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -157,7 +157,6 @@ updateMaterial material query =
 
 defaultQuery : Query
 defaultQuery =
-    -- FIXME: provide a query |> setQueryImpact (Trigram "xxx") helper
     tShirtCotonIndia
 
 

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -4,7 +4,6 @@ import Array
 import Base64
 import Data.Country as Country exposing (Country)
 import Data.Db exposing (Db)
-import Data.Impact as Impact
 import Data.Material as Material exposing (Material)
 import Data.Process as Process
 import Data.Product as Product exposing (Product)
@@ -29,8 +28,7 @@ type alias Inputs =
 
 type alias Query =
     -- a shorter version than Inputs (identifiers only)
-    { impact : Impact.Trigram
-    , mass : Mass
+    { mass : Mass
     , material : Process.Uuid
     , product : Product.Id
     , countries : List Country.Code
@@ -74,10 +72,9 @@ fromQuery db query =
         lookups.countries
 
 
-toQuery : Impact.Trigram -> Inputs -> Query
-toQuery trigram inputs =
-    { impact = trigram
-    , mass = inputs.mass
+toQuery : Inputs -> Query
+toQuery inputs =
+    { mass = inputs.mass
     , material = inputs.material.uuid
     , product = inputs.product.id
     , countries = inputs.countries |> List.map .code
@@ -157,22 +154,16 @@ updateMaterial material query =
         |> updateStepCountry 0 material.defaultCountry
 
 
-setQueryImpact : Impact.Trigram -> Query -> Query
-setQueryImpact trigram query =
-    { query | impact = trigram }
-
-
-defaultQuery : Impact.Trigram -> Query
+defaultQuery : Query
 defaultQuery =
     -- FIXME: provide a query |> setQueryImpact (Trigram "xxx") helper
     tShirtCotonIndia
 
 
-tShirtCotonFrance : Impact.Trigram -> Query
-tShirtCotonFrance trigram =
+tShirtCotonFrance : Query
+tShirtCotonFrance =
     -- T-shirt circuit France
-    { impact = trigram
-    , mass = Mass.kilograms 0.17
+    { mass = Mass.kilograms 0.17
     , material = Process.Uuid "f211bbdb-415c-46fd-be4d-ddf199575b44"
     , product = Product.Id "13"
     , countries =
@@ -189,14 +180,10 @@ tShirtCotonFrance trigram =
     }
 
 
-tShirtPolyamideFrance : Impact.Trigram -> Query
-tShirtPolyamideFrance trigram =
-    let
-        query =
-            tShirtCotonFrance trigram
-    in
+tShirtPolyamideFrance : Query
+tShirtPolyamideFrance =
     -- T-shirt polyamide (provenance France) circuit France
-    { query
+    { tShirtCotonFrance
         | material = Process.Uuid "182fa424-1f49-4728-b0f1-cb4e4ab36392"
         , countries =
             [ Country.Code "FR"
@@ -208,14 +195,10 @@ tShirtPolyamideFrance trigram =
     }
 
 
-tShirtCotonEurope : Impact.Trigram -> Query
-tShirtCotonEurope trigram =
-    let
-        query =
-            tShirtCotonFrance trigram
-    in
+tShirtCotonEurope : Query
+tShirtCotonEurope =
     -- T-shirt circuit Europe
-    { query
+    { tShirtCotonFrance
         | countries =
             [ Country.Code "CN"
             , Country.Code "TR"
@@ -226,14 +209,10 @@ tShirtCotonEurope trigram =
     }
 
 
-tShirtCotonIndia : Impact.Trigram -> Query
-tShirtCotonIndia trigram =
-    let
-        query =
-            tShirtCotonFrance trigram
-    in
+tShirtCotonIndia : Query
+tShirtCotonIndia =
     -- T-shirt circuit Inde
-    { query
+    { tShirtCotonFrance
         | countries =
             [ Country.Code "CN"
             , Country.Code "IN"
@@ -244,14 +223,10 @@ tShirtCotonIndia trigram =
     }
 
 
-tShirtCotonAsie : Impact.Trigram -> Query
-tShirtCotonAsie trigram =
-    let
-        query =
-            tShirtCotonFrance trigram
-    in
-    -- T-shirt circuit Europe
-    { query
+tShirtCotonAsie : Query
+tShirtCotonAsie =
+    -- T-shirt circuit Asie
+    { tShirtCotonFrance
         | countries =
             [ Country.Code "CN"
             , Country.Code "CN"
@@ -262,11 +237,10 @@ tShirtCotonAsie trigram =
     }
 
 
-jupeCircuitAsie : Impact.Trigram -> Query
-jupeCircuitAsie trigram =
+jupeCircuitAsie : Query
+jupeCircuitAsie =
     -- Jupe circuit Asie
-    { impact = trigram
-    , mass = Mass.kilograms 0.3
+    { mass = Mass.kilograms 0.3
     , material = Process.Uuid "aee6709f-0864-4fc5-8760-68cb644a0021"
     , product = Product.Id "8"
     , countries =
@@ -283,11 +257,10 @@ jupeCircuitAsie trigram =
     }
 
 
-manteauCircuitEurope : Impact.Trigram -> Query
-manteauCircuitEurope trigram =
+manteauCircuitEurope : Query
+manteauCircuitEurope =
     -- Manteau circuit Europe
-    { impact = trigram
-    , mass = Mass.kilograms 0.95
+    { mass = Mass.kilograms 0.95
     , material = Process.Uuid "380c0d9c-2840-4390-bd3f-5c960f26f5ed"
     , product = Product.Id "9"
     , countries =
@@ -304,11 +277,10 @@ manteauCircuitEurope trigram =
     }
 
 
-pantalonCircuitEurope : Impact.Trigram -> Query
-pantalonCircuitEurope trigram =
+pantalonCircuitEurope : Query
+pantalonCircuitEurope =
     -- Pantalon circuit Europe
-    { impact = trigram
-    , mass = Mass.kilograms 0.45
+    { mass = Mass.kilograms 0.45
     , material = Process.Uuid "e5a6d538-f932-4242-98b4-3a0c6439629c"
     , product = Product.Id "10"
     , countries =
@@ -325,11 +297,10 @@ pantalonCircuitEurope trigram =
     }
 
 
-robeCircuitBangladesh : Impact.Trigram -> Query
-robeCircuitBangladesh trigram =
+robeCircuitBangladesh : Query
+robeCircuitBangladesh =
     -- Robe circuit Bangladesh
-    { impact = trigram
-    , mass = Mass.kilograms 0.5
+    { mass = Mass.kilograms 0.5
     , material = Process.Uuid "7a1ccc4a-2ea7-48dc-9ef0-d57066ea8fa5"
     , product = Product.Id "12"
     , countries =
@@ -346,14 +317,14 @@ robeCircuitBangladesh trigram =
     }
 
 
-presets : Impact.Trigram -> List Query
-presets trigram =
-    [ tShirtCotonFrance trigram
-    , tShirtCotonEurope trigram
-    , tShirtCotonAsie trigram
-    , jupeCircuitAsie trigram
-    , manteauCircuitEurope trigram
-    , pantalonCircuitEurope trigram
+presets : List Query
+presets =
+    [ tShirtCotonFrance
+    , tShirtCotonEurope
+    , tShirtCotonAsie
+    , jupeCircuitAsie
+    , manteauCircuitEurope
+    , pantalonCircuitEurope
     ]
 
 
@@ -391,7 +362,6 @@ encodeCustomCountryMixes v =
 decodeQuery : Decoder Query
 decodeQuery =
     Decode.succeed Query
-        |> Pipe.required "impact" Impact.decodeTrigram
         |> Pipe.required "mass" (Decode.map Mass.kilograms Decode.float)
         |> Pipe.required "material" (Decode.map Process.Uuid Decode.string)
         |> Pipe.required "product" (Decode.map Product.Id Decode.string)
@@ -405,8 +375,7 @@ decodeQuery =
 encodeQuery : Query -> Encode.Value
 encodeQuery query =
     Encode.object
-        [ ( "impact", Encode.string (Impact.toString query.impact) )
-        , ( "mass", Encode.float (Mass.inKilograms query.mass) )
+        [ ( "mass", Encode.float (Mass.inKilograms query.mass) )
         , ( "material", query.material |> Process.uuidToString |> Encode.string )
         , ( "product", query.product |> Product.idToString |> Encode.string )
         , ( "countries", Encode.list (Country.codeToString >> Encode.string) query.countries )

--- a/src/Data/LifeCycle.elm
+++ b/src/Data/LifeCycle.elm
@@ -66,14 +66,21 @@ getStepProp label prop default =
 
 fromQuery : Db -> Inputs.Query -> Result String LifeCycle
 fromQuery db =
-    Inputs.fromQuery db >> Result.map init
+    Inputs.fromQuery db >> Result.map (init db)
 
 
-init : Inputs -> LifeCycle
-init inputs =
+init : Db -> Inputs -> LifeCycle
+init db inputs =
     inputs.countries
         |> List.map2
-            (\( label, editable ) country -> Step.create label editable country)
+            (\( label, editable ) country ->
+                Step.create
+                    { db = db
+                    , label = label
+                    , editable = editable
+                    , country = country
+                    }
+            )
             [ ( Step.MaterialAndSpinning, False )
             , ( Step.WeavingKnitting, True )
             , ( Step.Ennoblement, True )

--- a/src/Data/Process.elm
+++ b/src/Data/Process.elm
@@ -361,15 +361,15 @@ decodeFromUuid processes =
             )
 
 
-decode : Decoder Process
-decode =
+decode : List Impact.Definition -> Decoder Process
+decode impacts =
     Decode.succeed Process
         |> Pipe.required "cat1" (Decode.string |> Decode.andThen (cat1FromString >> DecodeExtra.fromResult))
         |> Pipe.required "cat2" (Decode.string |> Decode.andThen (cat2FromString >> DecodeExtra.fromResult))
         |> Pipe.required "cat3" (Decode.string |> Decode.andThen (cat3FromString >> DecodeExtra.fromResult))
         |> Pipe.required "name" Decode.string
         |> Pipe.required "uuid" (Decode.map Uuid Decode.string)
-        |> Pipe.required "impacts" Impact.decodeImpacts
+        |> Pipe.required "impacts" (Impact.decodeImpacts impacts)
         |> Pipe.required "heat" (Decode.map Energy.megajoules Decode.float)
         |> Pipe.required "elec_pppm" Decode.float
         |> Pipe.required "elec" (Decode.map Energy.megajoules Decode.float)
@@ -377,9 +377,9 @@ decode =
         |> Pipe.required "alias" (Decode.maybe Decode.string)
 
 
-decodeList : Decoder (List Process)
-decodeList =
-    Decode.list decode
+decodeList : List Impact.Definition -> Decoder (List Process)
+decodeList impacts =
+    Decode.list (decode impacts)
 
 
 encode : Process -> Encode.Value

--- a/src/Data/Sample.elm
+++ b/src/Data/Sample.elm
@@ -1,6 +1,5 @@
 module Data.Sample exposing (..)
 
-import Data.Impact as Impact
 import Data.Inputs as Inputs exposing (..)
 import Data.Unit as Unit
 
@@ -31,331 +30,201 @@ samples : List SectionOrSample
 samples =
     [ section "Aucun paramétrage personnalisé"
         [ sample "impacts for tShirtCotonFrance"
-            { query = tShirtCotonFrance Impact.defaultTrigram
+            { query = tShirtCotonFrance
             , cch = Unit.impactFromFloat 4.4140271789664345
             , fwe = Unit.impactFromFloat 0.0003521486305115451
             }
         , sample "impacts for tShirtPolyamideFrance"
-            { query = tShirtPolyamideFrance Impact.defaultTrigram
+            { query = tShirtPolyamideFrance
             , cch = Unit.impactFromFloat 3.63950716554
             , fwe = Unit.impactFromFloat 0.00008881966487864669
             }
         , sample "impacts for tShirtCotonEurope"
-            { query = tShirtCotonEurope Impact.defaultTrigram
+            { query = tShirtCotonEurope
             , cch = Unit.impactFromFloat 7.64890610786178
             , fwe = Unit.impactFromFloat 0.0006161214340873961
             }
         , sample "impacts for tShirtCotonAsie"
-            { query = tShirtCotonAsie Impact.defaultTrigram
+            { query = tShirtCotonAsie
             , cch = Unit.impactFromFloat 9.134011147532242
             , fwe = Unit.impactFromFloat 0.0006163020477764167
             }
         , sample "impacts for jupeCircuitAsie"
-            { query = jupeCircuitAsie Impact.defaultTrigram
+            { query = jupeCircuitAsie
             , cch = Unit.impactFromFloat 32.22983649812159
             , fwe = Unit.impactFromFloat 0.0006626107681986996
             }
         , sample "impacts for manteauCircuitEurope"
-            { query = manteauCircuitEurope Impact.defaultTrigram
+            { query = manteauCircuitEurope
             , cch = Unit.impactFromFloat 513.1648102863231
             , fwe = Unit.impactFromFloat 0.0028863508114862564
             }
         , sample "impacts for pantalonCircuitEurope"
-            { query = pantalonCircuitEurope Impact.defaultTrigram
+            { query = pantalonCircuitEurope
             , cch = Unit.impactFromFloat 23.110224611211542
             , fwe = Unit.impactFromFloat 0.001538902892541837
             }
         , sample "impacts for robeCircuitBangladesh"
-            { query = robeCircuitBangladesh Impact.defaultTrigram
+            { query = robeCircuitBangladesh
             , cch = Unit.impactFromFloat 39.709802008995126
             , fwe = Unit.impactFromFloat 0.0002608076513636336
             }
         ]
     , section "Majoration de teinture personnalisée"
         [ sample "impacts for tShirtCotonFrance using custom dyeing weighting"
-            (let
-                query =
-                    tShirtCotonFrance Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 4.877918477816435
-             , fwe = Unit.impactFromFloat 0.00048420985564356846
-             }
-            )
+            { query = { tShirtCotonFrance | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 4.877918477816435
+            , fwe = Unit.impactFromFloat 0.00048420985564356846
+            }
         , sample "impacts for tShirtPolyamideFrance using custom dyeing weighting"
-            (let
-                query =
-                    tShirtPolyamideFrance Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 4.103398464390001
-             , fwe = Unit.impactFromFloat 0.00022088089001067005
-             }
-            )
+            { query = { tShirtPolyamideFrance | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 4.103398464390001
+            , fwe = Unit.impactFromFloat 0.00022088089001067005
+            }
         , sample "impacts for tShirtCotonEurope using custom dyeing weighting"
-            (let
-                query =
-                    tShirtCotonEurope Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 6.463362123195113
-             , fwe = Unit.impactFromFloat 0.00048408368308020954
-             }
-            )
+            { query = { tShirtCotonEurope | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 6.463362123195113
+            , fwe = Unit.impactFromFloat 0.00048408368308020954
+            }
         , sample "impacts for tShirtCotonAsie using custom dyeing weighting"
-            (let
-                query =
-                    tShirtCotonAsie Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 7.733538029532242
-             , fwe = Unit.impactFromFloat 0.0004842569335390633
-             }
-            )
+            { query = { tShirtCotonAsie | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 7.733538029532242
+            , fwe = Unit.impactFromFloat 0.0004842569335390633
+            }
         , sample "impacts for jupeCircuitAsie using custom dyeing weighting"
-            (let
-                query =
-                    jupeCircuitAsie Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 29.603949401871592
-             , fwe = Unit.impactFromFloat 0.00041502617900366224
-             }
-            )
+            { query = { jupeCircuitAsie | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 29.603949401871592
+            , fwe = Unit.impactFromFloat 0.00041502617900366224
+            }
         , sample "impacts for manteauCircuitEurope using custom dyeing weighting"
-            (let
-                query =
-                    manteauCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 506.1256428773649
-             , fwe = Unit.impactFromFloat 0.002102376664881086
-             }
-            )
+            { query = { manteauCircuitEurope | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 506.1256428773649
+            , fwe = Unit.impactFromFloat 0.002102376664881086
+            }
         , sample "impacts for pantalonCircuitEurope using custom dyeing weighting"
-            (let
-                query =
-                    pantalonCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 20.018083385586536
-             , fwe = Unit.impactFromFloat 0.0011675520699323278
-             }
-            )
+            { query = { pantalonCircuitEurope | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 20.018083385586536
+            , fwe = Unit.impactFromFloat 0.0011675520699323278
+            }
         , sample "impacts for robeCircuitBangladesh using custom dyeing weighting"
-            (let
-                query =
-                    robeCircuitBangladesh Impact.defaultTrigram
-             in
-             { query = { query | dyeingWeighting = Just 0.5 }
-             , cch = Unit.impactFromFloat 42.31737586191179
-             , fwe = Unit.impactFromFloat 0.0006734506677003212
-             }
-            )
+            { query = { robeCircuitBangladesh | dyeingWeighting = Just 0.5 }
+            , cch = Unit.impactFromFloat 42.31737586191179
+            , fwe = Unit.impactFromFloat 0.0006734506677003212
+            }
         ]
     , section "Transport aérien personnalisé"
         [ sample "impacts for tShirtCotonFrance using custom air transport ratio"
-            (let
-                query =
-                    tShirtCotonFrance Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 4.4587926414664345
-             , fwe = Unit.impactFromFloat 0.0003521474420415451
-             }
-            )
+            { query = { tShirtCotonFrance | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 4.4587926414664345
+            , fwe = Unit.impactFromFloat 0.0003521474420415451
+            }
         , sample "impacts for tShirtPolyamideFrance using custom air transport ratio"
-            (let
-                query =
-                    tShirtPolyamideFrance Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 3.68427262804
-             , fwe = Unit.impactFromFloat 0.00008881847640864668
-             }
-            )
+            { query = { tShirtPolyamideFrance | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 3.68427262804
+            , fwe = Unit.impactFromFloat 0.00008881847640864668
+            }
         , sample "impacts for tShirtCotonEurope using custom air transport ratio"
-            (let
-                query =
-                    tShirtCotonEurope Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 7.75173387553888
-             , fwe = Unit.impactFromFloat 0.0006161245568596139
-             }
-            )
+            { query = { tShirtCotonEurope | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 7.75173387553888
+            , fwe = Unit.impactFromFloat 0.0006161245568596139
+            }
         , sample "impacts for tShirtCotonAsie using custom air transport ratio"
-            (let
-                query =
-                    tShirtCotonAsie Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 9.390536307076001
-             , fwe = Unit.impactFromFloat 0.0006163353667731165
-             }
-            )
+            { query = { tShirtCotonAsie | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 9.390536307076001
+            , fwe = Unit.impactFromFloat 0.0006163353667731165
+            }
         , sample "impacts for jupeCircuitAsie using custom air transport ratio"
-            (let
-                query =
-                    jupeCircuitAsie Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 32.68252795613999
-             , fwe = Unit.impactFromFloat 0.0006626695664281698
-             }
-            )
+            { query = { jupeCircuitAsie | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 32.68252795613999
+            , fwe = Unit.impactFromFloat 0.0006626695664281698
+            }
         , sample "impacts for manteauCircuitEurope using custom air transport ratio"
-            (let
-                query =
-                    manteauCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 513.7394360468716
-             , fwe = Unit.impactFromFloat 0.0028863682622721795
-             }
-            )
+            { query = { manteauCircuitEurope | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 513.7394360468716
+            , fwe = Unit.impactFromFloat 0.0028863682622721795
+            }
         , sample "impacts for pantalonCircuitEurope using custom air transport ratio"
-            (let
-                query =
-                    pantalonCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 23.28815979314244
-             , fwe = Unit.impactFromFloat 0.0015389172940433644
-             }
-            )
+            { query = { pantalonCircuitEurope | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 23.28815979314244
+            , fwe = Unit.impactFromFloat 0.0015389172940433644
+            }
         , sample "impacts for robeCircuitBangladesh using custom air transport ratio"
-            (let
-                query =
-                    robeCircuitBangladesh Impact.defaultTrigram
-             in
-             { query = { query | airTransportRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 40.110884473845125
-             , fwe = Unit.impactFromFloat 0.0002608599404572461
-             }
-            )
+            { query = { robeCircuitBangladesh | airTransportRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 40.110884473845125
+            , fwe = Unit.impactFromFloat 0.0002608599404572461
+            }
         ]
     , section "Part de matière recyclée personnalisée"
         [ sample "impacts for tShirtCotonFrance using no recycled ratio"
-            (let
-                query =
-                    tShirtCotonFrance Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0 }
-             , cch = Unit.impactFromFloat 4.4140271789664345
-             , fwe = Unit.impactFromFloat 0.0003521486305115451
-             }
-            )
+            { query = { tShirtCotonFrance | recycledRatio = Just 0 }
+            , cch = Unit.impactFromFloat 4.4140271789664345
+            , fwe = Unit.impactFromFloat 0.0003521486305115451
+            }
         , sample "impacts for tShirtCotonFrance using half recycled ratio"
-            (let
-                query =
-                    tShirtCotonFrance Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 2.8331446781664327
-             , fwe = Unit.impactFromFloat 0.00022337969643154514
-             }
-            )
+            { query = { tShirtCotonFrance | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 2.8331446781664327
+            , fwe = Unit.impactFromFloat 0.00022337969643154514
+            }
         , sample "impacts for tShirtCotonFrance using full recycled ratio"
-            (let
-                query =
-                    tShirtCotonFrance Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 1 }
-             , cch = Unit.impactFromFloat 1.2522621773664322
-             , fwe = Unit.impactFromFloat 0.00009461076235154518
-             }
-            )
+            { query = { tShirtCotonFrance | recycledRatio = Just 1 }
+            , cch = Unit.impactFromFloat 1.2522621773664322
+            , fwe = Unit.impactFromFloat 0.00009461076235154518
+            }
         , sample "impacts for tShirtPolyamideFrance using custom recycled ratio"
-            (let
-                query =
-                    tShirtPolyamideFrance Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 2.748975179940001
-             , fwe = Unit.impactFromFloat 0.00011238870391864669
-             }
-            )
+            { query = { tShirtPolyamideFrance | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 2.748975179940001
+            , fwe = Unit.impactFromFloat 0.00011238870391864669
+            }
         , sample "impacts for tShirtCotonEurope using custom recycled ratio"
-            (let
-                query =
-                    tShirtCotonEurope Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 6.06802360706178
-             , fwe = Unit.impactFromFloat 0.0004873525000073962
-             }
-            )
+            { query = { tShirtCotonEurope | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 6.06802360706178
+            , fwe = Unit.impactFromFloat 0.0004873525000073962
+            }
         , sample "impacts for tShirtCotonAsie using custom recycled ratio"
-            (let
-                query =
-                    tShirtCotonAsie Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 7.553128646732241
-             , fwe = Unit.impactFromFloat 0.00048753311369641655
-             }
-            )
+            { query = { tShirtCotonAsie | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 7.553128646732241
+            , fwe = Unit.impactFromFloat 0.00048753311369641655
+            }
         , sample "impacts for jupeCircuitAsie using custom recycled ratio"
-            (let
-                query =
-                    jupeCircuitAsie Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 29.85703235030909
-             , fwe = Unit.impactFromFloat 0.0007102758576861996
-             }
-            )
+            { query = { jupeCircuitAsie | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 29.85703235030909
+            , fwe = Unit.impactFromFloat 0.0007102758576861996
+            }
         , sample "impacts for manteauCircuitEurope using custom recycled ratio"
-            (let
-                query =
-                    manteauCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 513.1648102863231
-             , fwe = Unit.impactFromFloat 0.0028863508114862564
-             }
-            )
+            { query = { manteauCircuitEurope | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 513.1648102863231
+            , fwe = Unit.impactFromFloat 0.0028863508114862564
+            }
         , sample "impacts for pantalonCircuitEurope using custom recycled ratio"
-            (let
-                query =
-                    pantalonCircuitEurope Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 23.110224611211542
-             , fwe = Unit.impactFromFloat 0.001538902892541837
-             }
-            )
+            { query = { pantalonCircuitEurope | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 23.110224611211542
+            , fwe = Unit.impactFromFloat 0.001538902892541837
+            }
         , sample "impacts for robeCircuitBangladesh using custom recycled ratio"
-            (let
-                query =
-                    robeCircuitBangladesh Impact.defaultTrigram
-             in
-             { query = { query | recycledRatio = Just 0.5 }
-             , cch = Unit.impactFromFloat 39.709802008995126
-             , fwe = Unit.impactFromFloat 0.0002608076513636336
-             }
-            )
+            { query = { robeCircuitBangladesh | recycledRatio = Just 0.5 }
+            , cch = Unit.impactFromFloat 39.709802008995126
+            , fwe = Unit.impactFromFloat 0.0002608076513636336
+            }
         ]
     , section "Mix énergétique personnalisé"
         [ Section "À l'étape Tissage/Tricotage"
             [ sample "impacts for tShirtCotonFrance using custom country mix of 0"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 0))
                 , cch = Unit.impactFromFloat 4.374992378966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 0.5"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 0.5))
                 , cch = Unit.impactFromFloat 4.614992378966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 1.7"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 1.7))
                 , cch = Unit.impactFromFloat 5.190992378966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
@@ -364,21 +233,21 @@ samples =
         , section "À l'étape de Teinture"
             [ sample "impacts for tShirtCotonFrance using custom country mix of 0"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 0))
                 , cch = Unit.impactFromFloat 4.3816337164664345
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 0.5"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 0.5))
                 , cch = Unit.impactFromFloat 4.580800383133101
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 1.7"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 1.7))
                 , cch = Unit.impactFromFloat 5.058800383133101
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
@@ -387,21 +256,21 @@ samples =
         , section "À l'étape de Confection"
             [ sample "impacts for tShirtCotonFrance using custom country mix of 0"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 0))
                 , cch = Unit.impactFromFloat 4.373365928966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 0.5"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 0.5))
                 , cch = Unit.impactFromFloat 4.623365928966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 1.7"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 1.7))
                 , cch = Unit.impactFromFloat 5.223365928966434
                 , fwe = Unit.impactFromFloat 0.0003521486305115451
@@ -410,7 +279,7 @@ samples =
         , section "À toutes les étapes"
             [ sample "impacts for tShirtCotonFrance using custom country mix of 0"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 0))
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 0))
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 0))
@@ -419,7 +288,7 @@ samples =
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 0.5"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 0.5))
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 0.5))
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 0.5))
@@ -428,7 +297,7 @@ samples =
                 }
             , sample "impacts for tShirtCotonFrance using custom country mix of 1.7"
                 { query =
-                    tShirtCotonFrance Impact.defaultTrigram
+                    tShirtCotonFrance
                         |> Inputs.setCustomCountryMix 1 (Just (Unit.impactFromFloat 1.7))
                         |> Inputs.setCustomCountryMix 2 (Just (Unit.impactFromFloat 1.7))
                         |> Inputs.setCustomCountryMix 3 (Just (Unit.impactFromFloat 1.7))

--- a/src/Data/Simulator.elm
+++ b/src/Data/Simulator.elm
@@ -127,7 +127,7 @@ computeMakingImpact ({ inputs } as simulator) =
 
 
 computeDyeingImpact : Db -> Simulator -> Result String Simulator
-computeDyeingImpact { processes } ({ inputs } as simulator) =
+computeDyeingImpact { processes } simulator =
     processes
         |> Process.loadWellKnown
         |> Result.map

--- a/src/Data/Simulator.elm
+++ b/src/Data/Simulator.elm
@@ -38,7 +38,7 @@ init db =
         >> Result.map
             (\inputs ->
                 inputs
-                    |> LifeCycle.init
+                    |> LifeCycle.init db
                     |> (\lifeCycle ->
                             { inputs = inputs
                             , lifeCycle = lifeCycle

--- a/src/Data/Simulator.elm
+++ b/src/Data/Simulator.elm
@@ -47,14 +47,6 @@ init db =
             )
 
 
-{-| Computes all impacts. Takes a Query and runs a simulation for each known impact.
--}
-computeAll : Db -> Inputs.Query -> Result String Impacts
-computeAll { impacts } _ =
-    -- FIXME: obsolete, remove me
-    Ok <| Impact.impactsFromDefinitons impacts
-
-
 {-| Computes a single impact.
 -}
 compute : Db -> Inputs.Query -> Result String Simulator

--- a/src/Data/Simulator.elm
+++ b/src/Data/Simulator.elm
@@ -32,6 +32,10 @@ encode v =
 
 init : Db -> Inputs.Query -> Result String Simulator
 init db =
+    let
+        defaultImpacts =
+            Impact.impactsFromDefinitons db.impacts
+    in
     Inputs.fromQuery db
         >> Result.map
             (\inputs ->
@@ -40,10 +44,8 @@ init db =
                     |> (\lifeCycle ->
                             { inputs = inputs
                             , lifeCycle = lifeCycle
-
-                            -- FIXME: mutualize default impacts
-                            , impacts = Impact.impactsFromDefinitons db.impacts
-                            , transport = Transport.default (Impact.impactsFromDefinitons db.impacts)
+                            , impacts = defaultImpacts
+                            , transport = Transport.default defaultImpacts
                             }
                        )
             )

--- a/src/Data/Simulator.elm
+++ b/src/Data/Simulator.elm
@@ -40,8 +40,10 @@ init db =
                     |> (\lifeCycle ->
                             { inputs = inputs
                             , lifeCycle = lifeCycle
+
+                            -- FIXME: mutualize default impacts
                             , impacts = Impact.impactsFromDefinitons db.impacts
-                            , transport = Transport.default
+                            , transport = Transport.default (Impact.impactsFromDefinitons db.impacts)
                             }
                        )
             )
@@ -87,7 +89,7 @@ compute db query =
         -- Compute step transport
         |> nextWithDb computeStepsTransport
         -- Compute transport summary
-        |> next computeTotalTransports
+        |> next (computeTotalTransports db)
         --
         -- FINAL CO2 SCORE
         --
@@ -249,13 +251,13 @@ computeMaterialStepWaste ({ inputs, lifeCycle } as simulator) =
 computeStepsTransport : Db -> Simulator -> Result String Simulator
 computeStepsTransport db simulator =
     simulator.lifeCycle
-        |> LifeCycle.computeStepsTransport db simulator.inputs.impact
+        |> LifeCycle.computeStepsTransport db
         |> Result.map (\lifeCycle -> simulator |> updateLifeCycle (always lifeCycle))
 
 
-computeTotalTransports : Simulator -> Simulator
-computeTotalTransports simulator =
-    { simulator | transport = simulator.lifeCycle |> LifeCycle.computeTotalTransports }
+computeTotalTransports : Db -> Simulator -> Simulator
+computeTotalTransports db simulator =
+    { simulator | transport = simulator.lifeCycle |> LifeCycle.computeTotalTransports db }
 
 
 computeFinalImpacts : Db -> Simulator -> Simulator

--- a/src/Data/Step.elm
+++ b/src/Data/Step.elm
@@ -55,8 +55,12 @@ type Label
     | Distribution -- Distribution
 
 
-create : Label -> Bool -> Country -> Step
-create label editable country =
+create : { db : Db, label : Label, editable : Bool, country : Country } -> Step
+create { db, label, editable, country } =
+    let
+        impacts =
+            Impact.impactsFromDefinitons db.impacts
+    in
     { label = label
     , country = country
     , editable = editable

--- a/src/Data/Step.elm
+++ b/src/Data/Step.elm
@@ -4,7 +4,7 @@ import Data.Country as Country exposing (Country)
 import Data.Db exposing (Db)
 import Data.Formula as Formula
 import Data.Gitbook as Gitbook exposing (Path(..))
-import Data.Impact as Impact
+import Data.Impact as Impact exposing (Impacts)
 import Data.Inputs exposing (Inputs)
 import Data.Process as Process exposing (Process)
 import Data.Transport as Transport exposing (Transport, default, defaultInland)
@@ -26,7 +26,7 @@ type alias Step =
     , outputMass : Mass
     , waste : Mass
     , transport : Transport
-    , impact : Unit.Impact
+    , impacts : Impacts
     , heat : Energy
     , kwh : Energy
     , processInfo : ProcessInfo
@@ -57,10 +57,6 @@ type Label
 
 create : { db : Db, label : Label, editable : Bool, country : Country } -> Step
 create { db, label, editable, country } =
-    let
-        impacts =
-            Impact.impactsFromDefinitons db.impacts
-    in
     { label = label
     , country = country
     , editable = editable
@@ -68,7 +64,7 @@ create { db, label, editable, country } =
     , outputMass = Quantity.zero
     , waste = Quantity.zero
     , transport = Transport.default
-    , impact = Quantity.zero
+    , impacts = Impact.impactsFromDefinitons db.impacts
     , heat = Quantity.zero
     , kwh = Quantity.zero
     , processInfo = defaultProcessInfo
@@ -290,11 +286,6 @@ updateWaste waste mass step =
     }
 
 
-updateImpact : (Mass -> Unit.Impact) -> Step -> Step
-updateImpact compute step =
-    { step | impact = compute step.outputMass }
-
-
 airTransportRatioToString : Float -> String
 airTransportRatioToString airTransportRatio =
     case round (airTransportRatio * 100) of
@@ -339,7 +330,7 @@ encode v =
         , ( "outputMass", Encode.float (Mass.inKilograms v.outputMass) )
         , ( "waste", Encode.float (Mass.inKilograms v.waste) )
         , ( "transport", Transport.encode v.transport )
-        , ( "impact", Unit.encodeImpact v.impact )
+        , ( "impacts", Impact.encodeImpacts v.impacts )
         , ( "heat", Encode.float (Energy.inMegajoules v.heat) )
         , ( "kwh", Encode.float (Energy.inKilowattHours v.kwh) )
         , ( "processInfo", encodeProcessInfo v.processInfo )

--- a/src/Data/Step.elm
+++ b/src/Data/Step.elm
@@ -7,7 +7,7 @@ import Data.Gitbook as Gitbook exposing (Path(..))
 import Data.Impact as Impact exposing (Impacts)
 import Data.Inputs exposing (Inputs)
 import Data.Process as Process exposing (Process)
-import Data.Transport as Transport exposing (Transport, default, defaultInland)
+import Data.Transport as Transport exposing (Transport)
 import Data.Unit as Unit
 import Energy exposing (Energy)
 import FormatNumber
@@ -57,14 +57,18 @@ type Label
 
 create : { db : Db, label : Label, editable : Bool, country : Country } -> Step
 create { db, label, editable, country } =
+    let
+        defaultImpacts =
+            Impact.impactsFromDefinitons db.impacts
+    in
     { label = label
     , country = country
     , editable = editable
     , inputMass = Quantity.zero
     , outputMass = Quantity.zero
     , waste = Quantity.zero
-    , transport = Transport.default
-    , impacts = Impact.impactsFromDefinitons db.impacts
+    , transport = Transport.default defaultImpacts
+    , impacts = defaultImpacts
     , heat = Quantity.zero
     , kwh = Quantity.zero
     , processInfo = defaultProcessInfo
@@ -126,8 +130,8 @@ countryMixToString =
 Docs: <https://fabrique-numerique.gitbook.io/wikicarbone/methodologie/transport>
 
 -}
-computeTransports : Db -> Impact.Definition -> Step -> Step -> Result String Step
-computeTransports db impact next ({ processInfo } as current) =
+computeTransports : Db -> Step -> Step -> Result String Step
+computeTransports db next ({ processInfo } as current) =
     db.processes
         |> Process.loadWellKnown
         |> Result.map
@@ -135,7 +139,10 @@ computeTransports db impact next ({ processInfo } as current) =
                 let
                     transport =
                         db.transports
-                            |> Transport.getTransportBetween current.country.code next.country.code
+                            |> Transport.getTransportBetween
+                                current.transport.impacts
+                                current.country.code
+                                next.country.code
 
                     stepSummary =
                         computeTransportSummary current transport
@@ -152,7 +159,7 @@ computeTransports db impact next ({ processInfo } as current) =
                         }
                     , transport =
                         stepSummary
-                            |> computeTransportImpacts impact
+                            |> computeTransportImpacts current.transport.impacts
                                 wellKnown
                                 roadTransportProcess
                                 next.inputMass
@@ -160,30 +167,43 @@ computeTransports db impact next ({ processInfo } as current) =
             )
 
 
-computeTransportImpacts : Impact.Definition -> Process.WellKnown -> Process -> Mass -> Transport -> Transport
-computeTransportImpacts impact { seaTransport, airTransport } roadProcess mass { road, sea, air } =
-    let
-        ( roadImpact, seaImpact, airImpact ) =
-            -- TODO: refactor/simplify
-            ( mass |> Unit.forKgAndDistance (Process.getImpact impact.trigram roadProcess) road
-            , mass |> Unit.forKgAndDistance (Process.getImpact impact.trigram seaTransport) sea
-            , mass |> Unit.forKgAndDistance (Process.getImpact impact.trigram airTransport) air
-            )
-    in
+computeTransportImpacts : Impacts -> Process.WellKnown -> Process -> Mass -> Transport -> Transport
+computeTransportImpacts impacts { seaTransport, airTransport } roadProcess mass { road, sea, air } =
     { road = road
     , sea = sea
     , air = air
-    , impact = Quantity.sum [ roadImpact, seaImpact, airImpact ]
+    , impacts =
+        impacts
+            |> Impact.mapImpacts
+                (\trigram _ ->
+                    let
+                        ( roadImpact, seaImpact, airImpact ) =
+                            ( mass |> Unit.forKgAndDistance (Process.getImpact trigram roadProcess) road
+                            , mass |> Unit.forKgAndDistance (Process.getImpact trigram seaTransport) sea
+                            , mass |> Unit.forKgAndDistance (Process.getImpact trigram airTransport) air
+                            )
+                    in
+                    Quantity.sum [ roadImpact, seaImpact, airImpact ]
+                )
     }
 
 
 computeTransportSummary : Step -> Transport -> Transport
 computeTransportSummary step transport =
+    let
+        -- TODO: define transport records
+        default =
+            Transport.default step.transport.impacts
+
+        defaultInland =
+            Transport.defaultInland step.transport.impacts
+    in
     case step.label of
         Ennoblement ->
-            -- Added intermediary defaultInland transport step to materialize
-            -- Processing + Dyeing steps (see Excel)
+            -- Added intermediary inland transport step
+            -- to materialize Processing + Dyeing steps (see Excel)
             { default
+              -- FIXME: use defaultInland
                 | road = transport.road |> Quantity.plus defaultInland.road
                 , sea = transport.sea |> Quantity.plus defaultInland.sea
             }

--- a/src/Data/Step.elm
+++ b/src/Data/Step.elm
@@ -203,7 +203,6 @@ computeTransportSummary step transport =
             -- Added intermediary inland transport step
             -- to materialize Processing + Dyeing steps (see Excel)
             { default
-              -- FIXME: use defaultInland
                 | road = transport.road |> Quantity.plus defaultInland.road
                 , sea = transport.sea |> Quantity.plus defaultInland.sea
             }

--- a/src/DumpPresets.elm
+++ b/src/DumpPresets.elm
@@ -1,7 +1,6 @@
 port module DumpPresets exposing (..)
 
 import Data.Db as Db
-import Data.Impact as Impact
 import Data.Inputs as Inputs
 import Data.Simulator as Simulator
 import Json.Encode as Encode
@@ -20,7 +19,7 @@ init { jsonDb } =
                 |> Db.buildFromJson
                 |> Result.andThen
                     (\db ->
-                        Inputs.presets Impact.defaultTrigram
+                        Inputs.presets
                             |> List.map (Simulator.compute db)
                             |> RE.combine
                     )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -118,8 +118,8 @@ setRoute maybeRoute ( { session } as model, cmds ) =
             Examples.init session
                 |> toPage ExamplesPage ExamplesMsg
 
-        Just (Route.Simulator maybeQuery) ->
-            Simulator.init maybeQuery session
+        Just (Route.Simulator trigram maybeQuery) ->
+            Simulator.init trigram maybeQuery session
                 |> toPage SimulatorPage SimulatorMsg
 
         Just Route.Stats ->

--- a/src/Page/Examples.elm
+++ b/src/Page/Examples.elm
@@ -46,7 +46,7 @@ viewExamples session =
                     [ text "Faire une simulation" ]
                 ]
             ]
-        , Inputs.presets Impact.defaultTrigram
+        , Inputs.presets
             |> List.map
                 (Simulator.compute session.db
                     >> SummaryView.view

--- a/src/Page/Examples.elm
+++ b/src/Page/Examples.elm
@@ -40,7 +40,7 @@ viewExamples session =
                 ]
             , div [ class "col-md-5 col-lg-4 col-xl-3 text-center text-md-end" ]
                 [ a
-                    [ Route.href (Route.Simulator Nothing)
+                    [ Route.href (Route.Simulator Impact.defaultTrigram Nothing)
                     , class "btn btn-primary w-100"
                     ]
                     [ text "Faire une simulation" ]

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -58,7 +58,7 @@ view session _ =
                             ]
                         ]
                     , div [ class "col-lg-5" ]
-                        [ Inputs.tShirtCotonFrance Impact.defaultTrigram
+                        [ Inputs.tShirtCotonFrance
                             |> Simulator.compute session.db
                             |> SummaryView.view
                                 { session = session

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -48,7 +48,7 @@ view session _ =
                             [ text "Comprendre, contribuer et faire émerger des valeurs de référence" ]
                         , div [ class "row mb-4" ]
                             [ div [ class "col-md-6 text-center text-md-end py-2" ]
-                                [ a [ class "btn btn-lg btn-primary", Route.href (Route.Simulator Nothing) ]
+                                [ a [ class "btn btn-lg btn-primary", Route.href (Route.Simulator Impact.defaultTrigram Nothing) ]
                                     [ text "Faire une simulation" ]
                                 ]
                             , div [ class "col-md-6 text-center text-md-start py-2" ]

--- a/src/Page/Simulator.elm
+++ b/src/Page/Simulator.elm
@@ -467,12 +467,12 @@ lifeCycleStepsView db { displayMode, impact } simulator =
         |> div [ class "pt-1" ]
 
 
-shareLinkView : Session -> Simulator -> Html Msg
-shareLinkView session simulator =
+shareLinkView : Session -> Impact.Trigram -> Simulator -> Html Msg
+shareLinkView session trigram simulator =
     let
         shareableLink =
             simulator.inputs
-                |> (Inputs.toQuery >> Just)
+                |> (Inputs.toQuery trigram >> Just)
                 |> Route.Simulator
                 |> Route.toString
                 |> (++) session.clientUrl
@@ -739,7 +739,7 @@ simulatorView ({ db } as session) model ({ inputs } as simulator) =
                             }
                     ]
                 , feedbackView
-                , shareLinkView session simulator
+                , shareLinkView session model.impact.trigram simulator
                 ]
             ]
         ]

--- a/src/Page/Simulator.elm
+++ b/src/Page/Simulator.elm
@@ -42,6 +42,7 @@ import Views.Summary as SummaryView
 type alias Model =
     { simulator : Result String Simulator
     , massInput : String
+    , initialQuery : Inputs.Query
     , query : Inputs.Query
     , displayMode : DisplayMode
     , modal : ModalContent
@@ -142,6 +143,7 @@ init trigram maybeQuery ({ db } as session) =
     in
     ( { simulator = simulator
       , massInput = query.mass |> Mass.inKilograms |> String.fromFloat
+      , initialQuery = query
       , query = query
       , displayMode = SimpleMode
       , modal = NoModal
@@ -470,7 +472,6 @@ lifeCycleStepsView db { displayMode, impact } simulator =
 shareLinkView : Session -> Model -> Simulator -> Html Msg
 shareLinkView session { impact } simulator =
     let
-        -- FIXME: add trigram to sharebable link
         shareableLink =
             simulator.inputs
                 |> (Inputs.toQuery >> Just)
@@ -724,9 +725,7 @@ simulatorView ({ db } as session) model ({ inputs } as simulator) =
                 , button
                     [ class "btn btn-secondary"
                     , onClick Reset
-
-                    -- FIXME: store initial query and comare to it
-                    , disabled (model.query == Inputs.defaultQuery)
+                    , disabled (model.query == model.initialQuery)
                     ]
                     [ text "Réinitialiser le simulateur" ]
                 ]

--- a/src/Request/Db.elm
+++ b/src/Request/Db.elm
@@ -27,55 +27,72 @@ getJson decoder file =
 
 
 buildFromWebData :
-    List Process
-    -> WebData (List Impact.Definition)
+    List Impact.Definition
+    -> List Process
     -> WebData (List Country)
     -> WebData (List Material)
     -> WebData (List Product)
     -> WebData Distances
     -> WebData Db
-buildFromWebData processes impacts countries materials products transports =
-    RemoteData.succeed (Db processes)
-        |> RemoteData.andMap impacts
+buildFromWebData impacts processes countries materials products transports =
+    RemoteData.succeed (Db impacts processes)
         |> RemoteData.andMap countries
         |> RemoteData.andMap materials
         |> RemoteData.andMap products
         |> RemoteData.andMap transports
 
 
-loadProcessesDependentData : List Process -> Task () (WebData Db)
-loadProcessesDependentData processes =
+loadDependentData : List Impact.Definition -> List Process -> Task () (WebData Db)
+loadDependentData impacts processes =
     let
         -- see https://github.com/alex-tan/task-extra/blob/1.1.0/src/Task/Extra.elm#L579-L581
         andMap =
             Task.map2 (|>)
     in
-    Task.succeed (buildFromWebData processes)
-        |> andMap (getJson Impact.decodeList "impacts.json")
+    Task.succeed (buildFromWebData impacts processes)
         |> andMap (getJson (Country.decodeList processes) "countries.json")
         |> andMap (getJson (Material.decodeList processes) "materials.json")
         |> andMap (getJson (Product.decodeList processes) "products.json")
         |> andMap (getJson Transport.decodeDistances "transports.json")
 
 
+handleProcessesLoaded : List Impact.Definition -> WebData (List Process) -> Task () (WebData Db)
+handleProcessesLoaded impacts processesData =
+    case processesData of
+        RemoteData.Success processes ->
+            loadDependentData impacts processes
+
+        RemoteData.Failure error ->
+            Task.succeed (RemoteData.Failure error)
+
+        RemoteData.NotAsked ->
+            Task.succeed RemoteData.NotAsked
+
+        RemoteData.Loading ->
+            Task.succeed RemoteData.Loading
+
+
+handleImpactsLoaded : WebData (List Impact.Definition) -> Task () (WebData Db)
+handleImpactsLoaded impactsData =
+    case impactsData of
+        RemoteData.Success impacts ->
+            getJson (Process.decodeList impacts) "processes.json"
+                |> Task.andThen (handleProcessesLoaded impacts)
+
+        RemoteData.Failure error ->
+            Task.succeed (RemoteData.Failure error)
+
+        RemoteData.NotAsked ->
+            Task.succeed RemoteData.NotAsked
+
+        RemoteData.Loading ->
+            Task.succeed RemoteData.Loading
+
+
 loadDb : Session -> (WebData Db -> msg) -> Cmd msg
 loadDb _ event =
-    getJson Process.decodeList "processes.json"
-        |> Task.andThen
-            (\processesData ->
-                case processesData of
-                    RemoteData.Success processes ->
-                        loadProcessesDependentData processes
-
-                    RemoteData.Failure error ->
-                        Task.succeed (RemoteData.Failure error)
-
-                    RemoteData.NotAsked ->
-                        Task.succeed RemoteData.NotAsked
-
-                    RemoteData.Loading ->
-                        Task.succeed RemoteData.Loading
-            )
+    getJson Impact.decodeList "impacts.json"
+        |> Task.andThen handleImpactsLoaded
         |> Task.attempt
             (\result ->
                 case result of

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,7 +1,6 @@
 module Route exposing (Route(..), fromUrl, href, pushUrl, toString)
 
 import Browser.Navigation as Nav
-import Data.Impact as Impact
 import Data.Inputs as Inputs
 import Html exposing (Attribute)
 import Html.Attributes as Attr
@@ -37,7 +36,7 @@ parseInputsQuery =
         |> Parser.map
             (Inputs.b64decode
                 >> Result.toMaybe
-                >> Maybe.withDefault (Inputs.defaultQuery Impact.defaultTrigram)
+                >> Maybe.withDefault Inputs.defaultQuery
             )
 
 

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -26,33 +26,9 @@ parser =
         , Parser.map Editorial (Parser.s "content" </> Parser.string)
         , Parser.map Examples (Parser.s "examples")
         , Parser.map (Simulator Impact.defaultTrigram Nothing) (Parser.s "simulator")
-        , Parser.map Simulator (Parser.s "simulator" </> parseTrigram </> parseInputsQuery)
+        , Parser.map Simulator (Parser.s "simulator" </> Impact.parseTrigram </> Inputs.parseBase64Query)
         , Parser.map Stats (Parser.s "stats")
         ]
-
-
-parseTrigram : Parser (Impact.Trigram -> a) a
-parseTrigram =
-    let
-        trigrams =
-            "acd,ozd,cch,ccb,ccf,ccl,fwe,swe,tre,pco,pma,ior,fru,mru,ldu"
-                |> String.split ","
-    in
-    Parser.custom "TRIGRAM" <|
-        \trg ->
-            if List.member trg trigrams then
-                Just (Impact.trg trg)
-
-            else
-                Just Impact.defaultTrigram
-
-
-parseInputsQuery : Parser (Maybe Inputs.Query -> a) a
-parseInputsQuery =
-    Parser.custom "QUERY" <|
-        Inputs.b64decode
-            >> Result.toMaybe
-            >> Just
 
 
 {-| Note: as elm-kitten relies on URL fragment based routing, the source URL is

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -2,7 +2,6 @@ port module Server exposing (main)
 
 import Data.Country as Country
 import Data.Db as Db exposing (Db)
-import Data.Impact as Impact
 import Data.Inputs as Inputs
 import Data.Process as Process
 import Data.Product as Product
@@ -110,7 +109,6 @@ expressQueryDecoder =
                 |> Decode.maybe
     in
     Decode.succeed Inputs.Query
-        |> Pipe.optional "impact" Impact.decodeTrigram (Impact.trg "cch")
         |> Pipe.required "mass" (decodeStringFloat |> Decode.map Mass.kilograms)
         |> Pipe.required "material" (Decode.map Process.Uuid Decode.string)
         |> Pipe.required "product" (Decode.map Product.Id Decode.string)

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -2,6 +2,7 @@ port module Server exposing (main)
 
 import Data.Country as Country
 import Data.Db as Db exposing (Db)
+import Data.Impact as Impact
 import Data.Inputs as Inputs
 import Data.Process as Process
 import Data.Product as Product
@@ -12,6 +13,8 @@ import Json.Decode.Extra as DecodeExtra
 import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
 import Mass
+import Url
+import Url.Parser as Parser exposing ((</>), Parser)
 
 
 type alias Flags =
@@ -23,10 +26,8 @@ type alias Model =
     }
 
 
-type Route
-    = Home
-    | Simulator
-    | NotFound
+type Msg
+    = Received Request
 
 
 type alias Request =
@@ -42,8 +43,11 @@ type alias Request =
     }
 
 
-type Msg
-    = Received Request
+type Route
+    = Home
+    | Simulator -- Simple version of all impacts
+    | SimulatorDetailed -- Detailed version for all impacts
+    | SimulatorSingle Impact.Trigram -- Simple version for one specific impact
 
 
 init : Flags -> ( Model, Cmd Msg )
@@ -53,38 +57,20 @@ init { jsonDb } =
     )
 
 
-parseRoute : String -> Route
-parseRoute path =
-    case path of
-        "/" ->
-            Home
-
-        "/simulator/" ->
-            Simulator
-
-        _ ->
-            NotFound
+parser : Parser (Route -> a) a
+parser =
+    Parser.oneOf
+        [ Parser.map Home Parser.top
+        , Parser.map Simulator (Parser.s "simulator")
+        , Parser.map SimulatorDetailed (Parser.s "simulator" </> Parser.s "detailed")
+        , Parser.map SimulatorSingle (Parser.s "simulator" </> Impact.parseTrigram)
+        ]
 
 
-routeToString : Route -> Maybe String
-routeToString route =
-    case route of
-        Home ->
-            Just "/"
-
-        Simulator ->
-            Just "/simulator/"
-
-        NotFound ->
-            Nothing
-
-
-routes : List Route
-routes =
-    [ Home
-    , Simulator
-    , NotFound
-    ]
+parseRoute : String -> Maybe Route
+parseRoute expressPath =
+    Url.fromString ("http://x" ++ expressPath)
+        |> Maybe.andThen (Parser.parse parser)
 
 
 apiDocUrl : String
@@ -163,23 +149,69 @@ toResponse request encodedResult =
                 |> sendResponse 400 request
 
 
+toAllImpactsSimple : Simulator -> Encode.Value
+toAllImpactsSimple { inputs, impacts } =
+    Encode.object
+        [ ( "impacts", Impact.encodeImpacts impacts )
+        , ( "query", inputs |> Inputs.toQuery |> Inputs.encodeQuery )
+        ]
+
+
+toSingleImpactSimple : Impact.Trigram -> Simulator -> Encode.Value
+toSingleImpactSimple trigram { inputs, impacts } =
+    Encode.object
+        [ ( "impact"
+          , impacts
+                |> Impact.filterImpacts (\trg _ -> trigram == trg)
+                |> Impact.encodeImpacts
+          )
+        , ( "query", inputs |> Inputs.toQuery |> Inputs.encodeQuery )
+        ]
+
+
+executeQuery : Db -> (Simulator -> Encode.Value) -> Request -> Cmd Msg
+executeQuery db fn request =
+    decodeQuery request.expressQuery
+        |> Result.andThen (Simulator.compute db >> Result.map fn)
+        |> toResponse request
+
+
 handleRequest : Db -> Request -> Cmd Msg
-handleRequest db ({ expressPath, expressQuery } as request) =
+handleRequest db ({ expressPath } as request) =
     case parseRoute expressPath of
-        Home ->
+        Just Home ->
             Encode.object
                 [ ( "service", Encode.string "Wikicarbone" )
                 , ( "documentation", Encode.string apiDocUrl )
-                , ( "endpoints", routes |> List.filterMap routeToString |> Encode.list Encode.string )
+                , ( "endpoints"
+                  , Encode.object
+                        [ ( "GET /simulator/"
+                          , Encode.string "Simple version of all impacts"
+                          )
+                        , ( "GET /simulator/detailed/"
+                          , Encode.string "Detailed version for all impacts"
+                          )
+                        , ( "GET /simulator/<impact>/"
+                          , Encode.string "Simple version for one specific impact"
+                          )
+                        ]
+                  )
                 ]
                 |> sendResponse 200 request
 
-        Simulator ->
-            decodeQuery expressQuery
-                |> Result.andThen (Simulator.compute db >> Result.map Simulator.encode)
-                |> toResponse request
+        Just Simulator ->
+            request
+                |> executeQuery db toAllImpactsSimple
 
-        NotFound ->
+        Just SimulatorDetailed ->
+            request
+                |> executeQuery db Simulator.encode
+
+        Just (SimulatorSingle trigram) ->
+            request
+                |> executeQuery db (toSingleImpactSimple trigram)
+
+        Nothing ->
             encodeStringError "Endpoint doesn't exist"
                 |> sendResponse 404 request
 

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -27,7 +27,6 @@ type alias Model =
 type Route
     = Home
     | Simulator
-    | SimulatorAll
     | NotFound
 
 
@@ -64,9 +63,6 @@ parseRoute path =
         "/simulator/" ->
             Simulator
 
-        "/simulator/all/" ->
-            SimulatorAll
-
         _ ->
             NotFound
 
@@ -80,9 +76,6 @@ routeToString route =
         Simulator ->
             Just "/simulator/"
 
-        SimulatorAll ->
-            Just "/simulator/all/"
-
         NotFound ->
             Nothing
 
@@ -91,7 +84,6 @@ routes : List Route
 routes =
     [ Home
     , Simulator
-    , SimulatorAll
     , NotFound
     ]
 
@@ -187,11 +179,6 @@ handleRequest db ({ expressPath, expressQuery } as request) =
         Simulator ->
             decodeQuery expressQuery
                 |> Result.andThen (Simulator.compute db >> Result.map Simulator.encode)
-                |> toResponse request
-
-        SimulatorAll ->
-            decodeQuery expressQuery
-                |> Result.andThen (Simulator.computeAll db >> Result.map Impact.encodeImpacts)
                 |> toResponse request
 
         NotFound ->

--- a/src/Views/BarChart.elm
+++ b/src/Views/BarChart.elm
@@ -88,7 +88,7 @@ barView { impact } bar =
     tr [ class "fs-7" ]
         [ th [ class "text-end text-truncate py-1 pe-1" ] [ bar.label ]
         , td [ class "d-none d-sm-block text-end py-1 ps-1 pe-2 text-truncate" ]
-            [ Format.formatImpact impact (Unit.impactFromFloat bar.score)
+            [ Format.formatImpactFloat impact bar.score
             ]
         , td [ class "w-100 py-1" ]
             [ div

--- a/src/Views/BarChart.elm
+++ b/src/Views/BarChart.elm
@@ -28,13 +28,14 @@ type alias Bar msg =
 makeBars : Config -> List (Bar msg)
 makeBars { simulator, impact } =
     let
+        -- FIXME: mutualize grabImpact
         grabImpact =
             .impacts >> Impact.getImpact impact.trigram >> Unit.impactToFloat
 
         maxScore =
             simulator.lifeCycle
                 |> Array.map grabImpact
-                |> Array.push (Unit.impactToFloat simulator.transport.impact)
+                |> Array.push (grabImpact simulator.transport)
                 |> Array.toList
                 |> List.maximum
                 |> Maybe.withDefault 0
@@ -74,9 +75,9 @@ makeBars { simulator, impact } =
 
         transportBar =
             { label = text "Transport total"
-            , score = Unit.impactToFloat simulator.transport.impact
-            , width = clamp 0 100 (Unit.impactToFloat simulator.transport.impact / maxScore * toFloat 100)
-            , percent = Unit.impactToFloat simulator.transport.impact / grabImpact simulator * toFloat 100
+            , score = grabImpact simulator.transport
+            , width = clamp 0 100 (grabImpact simulator.transport / maxScore * toFloat 100)
+            , percent = grabImpact simulator.transport / grabImpact simulator * toFloat 100
             }
     in
     stepBars ++ [ transportBar ]

--- a/src/Views/BarChart.elm
+++ b/src/Views/BarChart.elm
@@ -4,7 +4,6 @@ import Array
 import Data.Impact as Impact
 import Data.Simulator exposing (Simulator)
 import Data.Step as Step
-import Data.Unit as Unit
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Views.Format as Format
@@ -28,9 +27,8 @@ type alias Bar msg =
 makeBars : Config -> List (Bar msg)
 makeBars { simulator, impact } =
     let
-        -- FIXME: mutualize grabImpact
         grabImpact =
-            .impacts >> Impact.getImpact impact.trigram >> Unit.impactToFloat
+            Impact.grabImpactFloat impact.trigram
 
         maxScore =
             simulator.lifeCycle

--- a/src/Views/BarChart.elm
+++ b/src/Views/BarChart.elm
@@ -26,11 +26,14 @@ type alias Bar msg =
 
 
 makeBars : Config -> List (Bar msg)
-makeBars { simulator } =
+makeBars { simulator, impact } =
     let
+        grabImpact =
+            .impacts >> Impact.getImpact impact.trigram >> Unit.impactToFloat
+
         maxScore =
             simulator.lifeCycle
-                |> Array.map (.impact >> Unit.impactToFloat)
+                |> Array.map grabImpact
                 |> Array.push (Unit.impactToFloat simulator.transport.impact)
                 |> Array.toList
                 |> List.maximum
@@ -63,9 +66,9 @@ makeBars { simulator } =
                                     _ ->
                                         text (Step.labelToString step.label)
                                 ]
-                        , score = Unit.impactToFloat step.impact
-                        , width = clamp 0 100 (Unit.impactToFloat step.impact / maxScore * toFloat 100)
-                        , percent = Unit.impactToFloat step.impact / Unit.impactToFloat simulator.impact * toFloat 100
+                        , score = grabImpact step
+                        , width = clamp 0 100 (grabImpact step / maxScore * toFloat 100)
+                        , percent = grabImpact step / grabImpact simulator * toFloat 100
                         }
                     )
 
@@ -73,7 +76,7 @@ makeBars { simulator } =
             { label = text "Transport total"
             , score = Unit.impactToFloat simulator.transport.impact
             , width = clamp 0 100 (Unit.impactToFloat simulator.transport.impact / maxScore * toFloat 100)
-            , percent = Unit.impactToFloat simulator.transport.impact / Unit.impactToFloat simulator.impact * toFloat 100
+            , percent = Unit.impactToFloat simulator.transport.impact / grabImpact simulator * toFloat 100
             }
     in
     stepBars ++ [ transportBar ]

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -192,7 +192,7 @@ getEntries : Db -> Impact.Definition -> Inputs -> Result String (List Entry)
 getEntries db impact ({ material } as inputs) =
     let
         query =
-            Inputs.toQuery impact.trigram inputs
+            Inputs.toQuery inputs
 
         entries =
             if material.recycledProcess /= Nothing then

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -160,10 +160,6 @@ toNonRecycledIndia query =
 createEntry : Db -> Impact.Definition -> Bool -> ( String, Inputs.Query ) -> Result String Entry
 createEntry db { trigram } highlight ( label, query ) =
     let
-        -- FIXME: mutualize grabImpact
-        grabImpact =
-            .impacts >> Impact.getImpact trigram >> Unit.impactToFloat
-
         stepScore stepLabel lifeCycle =
             lifeCycle
                 |> LifeCycle.getStepProp stepLabel
@@ -178,12 +174,12 @@ createEntry db { trigram } highlight ( label, query ) =
                 { label = label
                 , highlight = highlight
                 , knitted = inputs.product.knitted
-                , score = grabImpact simulator
+                , score = Impact.grabImpactFloat trigram simulator
                 , materialAndSpinning = lifeCycle |> stepScore Step.MaterialAndSpinning
                 , weavingKnitting = lifeCycle |> stepScore Step.WeavingKnitting
                 , dyeing = lifeCycle |> stepScore Step.Ennoblement
                 , making = lifeCycle |> stepScore Step.Making
-                , transport = grabImpact transport
+                , transport = Impact.grabImpactFloat trigram transport
                 }
             )
 

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -160,6 +160,7 @@ toNonRecycledIndia query =
 createEntry : Db -> Impact.Definition -> Bool -> ( String, Inputs.Query ) -> Result String Entry
 createEntry db { trigram } highlight ( label, query ) =
     let
+        -- FIXME: mutualize grabImpact
         grabImpact =
             .impacts >> Impact.getImpact trigram >> Unit.impactToFloat
 
@@ -182,7 +183,7 @@ createEntry db { trigram } highlight ( label, query ) =
                 , weavingKnitting = lifeCycle |> stepScore Step.WeavingKnitting
                 , dyeing = lifeCycle |> stepScore Step.Ennoblement
                 , making = lifeCycle |> stepScore Step.Making
-                , transport = Unit.impactToFloat transport.impact
+                , transport = grabImpact transport
                 }
             )
 

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -192,7 +192,7 @@ getEntries : Db -> Impact.Definition -> Inputs -> Result String (List Entry)
 getEntries db impact ({ material } as inputs) =
     let
         query =
-            Inputs.toQuery inputs
+            Inputs.toQuery impact.trigram inputs
 
         entries =
             if material.recycledProcess /= Nothing then

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -1,6 +1,6 @@
 module Views.Format exposing (..)
 
-import Data.Impact as Impact
+import Data.Impact as Impact exposing (Impacts)
 import Data.Unit as Unit
 import Decimal
 import Energy exposing (Energy)
@@ -12,9 +12,16 @@ import Length exposing (Length)
 import Mass exposing (Mass)
 
 
-formatImpact : Impact.Definition -> Unit.Impact -> Html msg
-formatImpact { unit } =
-    Unit.impactToFloat >> formatRichFloat 2 unit
+formatImpact : Impact.Definition -> Impacts -> Html msg
+formatImpact { trigram, unit } =
+    Impact.getImpact trigram
+        >> Unit.impactToFloat
+        >> formatRichFloat 2 unit
+
+
+formatImpactFloat : Impact.Definition -> Float -> Html msg
+formatImpactFloat { unit } =
+    formatRichFloat 2 unit
 
 
 formatInt : String -> Int -> String

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -1,6 +1,7 @@
 module Views.Page exposing (..)
 
 import Browser exposing (Document)
+import Data.Impact as Impact
 import Data.Session as Session exposing (Session)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -79,7 +80,7 @@ stagingAlert { session, loadUrl } =
 headerMenuLinks : List MenuLink
 headerMenuLinks =
     [ Internal "Accueil" Route.Home Home
-    , Internal "Simulateur" (Route.Simulator Nothing) Simulator
+    , Internal "Simulateur" (Route.Simulator Impact.defaultTrigram Nothing) Simulator
     , Internal "Exemples" Route.Examples Examples
     , External "Documentation" "https://fabrique-numerique.gitbook.io/wikicarbone/"
     ]
@@ -88,7 +89,7 @@ headerMenuLinks =
 footerMenuLinks : List MenuLink
 footerMenuLinks =
     [ Internal "Accueil" Route.Home Home
-    , Internal "Simulateur" (Route.Simulator Nothing) Simulator
+    , Internal "Simulateur" (Route.Simulator Impact.defaultTrigram Nothing) Simulator
     , Internal "Exemples" Route.Examples Examples
     , Internal "Changelog" Route.Changelog Changelog
     , Internal "Statistiques" Route.Stats Stats

--- a/src/Views/Step.elm
+++ b/src/Views/Step.elm
@@ -150,7 +150,10 @@ simpleView ({ inputs, impact, index, current } as config) =
                 [ div []
                     [ if current.label /= Step.Distribution then
                         div [ class "fs-3 fw-normal text-secondary" ]
-                            [ Format.formatImpact impact current.impact
+                            [ -- FIXME: do not duplicate impact requirement
+                              current.impacts
+                                |> Impact.getImpact impact.trigram
+                                |> Format.formatImpact impact
                             ]
 
                       else
@@ -224,8 +227,15 @@ detailedView ({ inputs, impact, index, next, current } as config) =
         , div
             [ class "card text-center" ]
             [ div [ class "card-header text-muted" ]
-                [ if Unit.impactToFloat current.impact > 0 then
-                    span [ class "fw-bold" ] [ Format.formatImpact impact current.impact ]
+                [ let
+                    impactValue =
+                        -- FIXME: do not duplicate impact requirement
+                        current.impacts
+                            |> Impact.getImpact impact.trigram
+                  in
+                  if Unit.impactToFloat impactValue > 0 then
+                    span [ class "fw-bold" ]
+                        [ Format.formatImpact impact impactValue ]
 
                   else
                     text "\u{00A0}"

--- a/src/Views/Step.elm
+++ b/src/Views/Step.elm
@@ -150,10 +150,7 @@ simpleView ({ inputs, impact, index, current } as config) =
                 [ div []
                     [ if current.label /= Step.Distribution then
                         div [ class "fs-3 fw-normal text-secondary" ]
-                            [ -- FIXME: do not duplicate impact requirement
-                              current.impacts
-                                |> Impact.getImpact impact.trigram
-                                |> Format.formatImpact impact
+                            [ current.impacts |> Format.formatImpact impact
                             ]
 
                       else
@@ -161,11 +158,7 @@ simpleView ({ inputs, impact, index, current } as config) =
                     , div [ class "fs-7" ]
                         [ span [ class "me-1 align-bottom" ] [ Icon.info ]
                         , text "Transport\u{00A0}"
-
-                        -- FIXME: do not duplicate impact requirement
-                        , current.transport.impacts
-                            |> Impact.getImpact impact.trigram
-                            |> Format.formatImpact impact
+                        , current.transport.impacts |> Format.formatImpact impact
                         ]
                     ]
                 ]
@@ -231,15 +224,9 @@ detailedView ({ inputs, impact, index, next, current } as config) =
         , div
             [ class "card text-center" ]
             [ div [ class "card-header text-muted" ]
-                [ let
-                    impactValue =
-                        -- FIXME: do not duplicate impact requirement
-                        current.impacts
-                            |> Impact.getImpact impact.trigram
-                  in
-                  if Unit.impactToFloat impactValue > 0 then
+                [ if (current.impacts |> Impact.getImpact impact.trigram |> Unit.impactToFloat) > 0 then
                     span [ class "fw-bold" ]
-                        [ Format.formatImpact impact impactValue ]
+                        [ current.impacts |> Format.formatImpact impact ]
 
                   else
                     text "\u{00A0}"
@@ -281,11 +268,7 @@ detailedView ({ inputs, impact, index, next, current } as config) =
                 , li [ class "list-group-item text-muted" ]
                     [ div [ class "d-flex justify-content-center align-items-center" ]
                         [ strong [] [ text <| transportLabel ++ "\u{00A0}:\u{00A0}" ]
-
-                        -- FIXME: do not duplicate impact requirement
-                        , current.transport.impacts
-                            |> Impact.getImpact impact.trigram
-                            |> Format.formatImpact impact
+                        , current.transport.impacts |> Format.formatImpact impact
                         , inlineDocumentationLink config Gitbook.Transport
                         ]
                     ]

--- a/src/Views/Step.elm
+++ b/src/Views/Step.elm
@@ -161,7 +161,11 @@ simpleView ({ inputs, impact, index, current } as config) =
                     , div [ class "fs-7" ]
                         [ span [ class "me-1 align-bottom" ] [ Icon.info ]
                         , text "Transport\u{00A0}"
-                        , Format.formatImpact impact current.transport.impact
+
+                        -- FIXME: do not duplicate impact requirement
+                        , current.transport.impacts
+                            |> Impact.getImpact impact.trigram
+                            |> Format.formatImpact impact
                         ]
                     ]
                 ]
@@ -277,7 +281,11 @@ detailedView ({ inputs, impact, index, next, current } as config) =
                 , li [ class "list-group-item text-muted" ]
                     [ div [ class "d-flex justify-content-center align-items-center" ]
                         [ strong [] [ text <| transportLabel ++ "\u{00A0}:\u{00A0}" ]
-                        , Format.formatImpact impact current.transport.impact
+
+                        -- FIXME: do not duplicate impact requirement
+                        , current.transport.impacts
+                            |> Impact.getImpact impact.trigram
+                            |> Format.formatImpact impact
                         , inlineDocumentationLink config Gitbook.Transport
                         ]
                     ]

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -44,10 +44,7 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
                     ]
                     []
                 , div [ class "display-5" ]
-                    [ -- FIXME: do not duplicate impact requirement
-                      simulator.impacts
-                        |> Impact.getImpact impact.trigram
-                        |> Format.formatImpact impact
+                    [ simulator.impacts |> Format.formatImpact impact
                     ]
                 ]
             , inputs.countries

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -54,7 +54,7 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
                 |> List.map (\{ name } -> li [] [ span [] [ text name ] ])
                 |> ul [ class "Chevrons" ]
             , lifeCycle
-                |> LifeCycle.computeTotalTransports
+                |> LifeCycle.computeTotalTransports session.db
                 |> TransportView.view
                     { fullWidth = False
                     , airTransportLabel = Just "Transport aérien total"

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -93,7 +93,7 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
                         (inputs
                             |> Inputs.toQuery
                             |> Just
-                            |> Route.Simulator
+                            |> Route.Simulator Impact.defaultTrigram
                         )
                     ]
                     [ text "Reprendre cette simulation" ]

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -91,7 +91,7 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
                     [ class "btn btn-primary"
                     , Route.href
                         (inputs
-                            |> Inputs.toQuery Impact.defaultTrigram
+                            |> Inputs.toQuery
                             |> Just
                             |> Route.Simulator
                         )

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -44,7 +44,10 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
                     ]
                     []
                 , div [ class "display-5" ]
-                    [ Format.formatImpact impact simulator.impact
+                    [ -- FIXME: do not duplicate impact requirement
+                      simulator.impacts
+                        |> Impact.getImpact impact.trigram
+                        |> Format.formatImpact impact
                     ]
                 ]
             , inputs.countries

--- a/src/Views/Summary.elm
+++ b/src/Views/Summary.elm
@@ -92,7 +92,12 @@ summaryView { session, impact, reusable } ({ inputs, lifeCycle } as simulator) =
             div [ class "card-footer text-center" ]
                 [ a
                     [ class "btn btn-primary"
-                    , Route.href (Route.Simulator (inputs |> Inputs.toQuery |> Just))
+                    , Route.href
+                        (inputs
+                            |> Inputs.toQuery Impact.defaultTrigram
+                            |> Just
+                            |> Route.Simulator
+                        )
                     ]
                     [ text "Reprendre cette simulation" ]
                 ]

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -1,6 +1,5 @@
 module Data.InputsTest exposing (..)
 
-import Data.Impact as Impact
 import Data.Inputs as Inputs
 import Expect exposing (Expectation)
 import Test exposing (..)
@@ -14,7 +13,7 @@ asTest label =
 
 sampleQuery : Inputs.Query
 sampleQuery =
-    Inputs.jupeCircuitAsie (Impact.trg "fwe")
+    Inputs.jupeCircuitAsie
 
 
 suite : Test
@@ -25,7 +24,7 @@ suite =
                 [ describe "Encoding and decoding queries"
                     [ sampleQuery
                         |> Inputs.fromQuery db
-                        |> Result.map (Inputs.toQuery (Impact.trg "fwe"))
+                        |> Result.map Inputs.toQuery
                         |> Expect.equal (Ok sampleQuery)
                         |> asTest "should encode and decode a query"
                     ]

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -25,7 +25,7 @@ suite =
                 [ describe "Encoding and decoding queries"
                     [ sampleQuery
                         |> Inputs.fromQuery db
-                        |> Result.map Inputs.toQuery
+                        |> Result.map (Inputs.toQuery (Impact.trg "fwe"))
                         |> Expect.equal (Ok sampleQuery)
                         |> asTest "should encode and decode a query"
                     ]

--- a/tests/Data/LifeCycleTest.elm
+++ b/tests/Data/LifeCycleTest.elm
@@ -4,7 +4,6 @@ import Data.Country as Country
 import Data.Impact as Impact
 import Data.Inputs exposing (tShirtCotonFrance)
 import Data.LifeCycle as LifeCycle
-import Data.Unit as Unit
 import Expect
 import Length
 import Test exposing (..)
@@ -19,20 +18,24 @@ suite : Test
 suite =
     case testDb of
         Ok db ->
+            let
+                defaultImpacts =
+                    Impact.impactsFromDefinitons db.impacts
+            in
             describe "Data.LifeCycle"
                 [ describe "computeTransportSummary"
                     [ test "should compute default distances" <|
                         \_ ->
                             tShirtCotonFrance Impact.defaultTrigram
                                 |> LifeCycle.fromQuery db
-                                |> Result.andThen (LifeCycle.computeStepsTransport db Impact.default)
-                                |> Result.map LifeCycle.computeTotalTransports
+                                |> Result.andThen (LifeCycle.computeStepsTransport db)
+                                |> Result.map (LifeCycle.computeTotalTransports db)
                                 |> Expect.equal
                                     (Ok
                                         { road = km 2500
                                         , sea = km 21548
                                         , air = km 0
-                                        , impact = Unit.impactFromFloat 0
+                                        , impacts = defaultImpacts
                                         }
                                     )
                     , test "should compute custom distances" <|
@@ -51,14 +54,14 @@ suite =
                                         , Country.Code "FR"
                                         ]
                                 }
-                                |> Result.andThen (LifeCycle.computeStepsTransport db Impact.default)
-                                |> Result.map LifeCycle.computeTotalTransports
+                                |> Result.andThen (LifeCycle.computeStepsTransport db)
+                                |> Result.map (LifeCycle.computeTotalTransports db)
                                 |> Expect.equal
                                     (Ok
                                         { road = km 1500
                                         , sea = km 45468
                                         , air = km 0
-                                        , impact = Unit.impactFromFloat 0
+                                        , impacts = defaultImpacts
                                         }
                                     )
                     ]

--- a/tests/Data/LifeCycleTest.elm
+++ b/tests/Data/LifeCycleTest.elm
@@ -26,7 +26,7 @@ suite =
                 [ describe "computeTransportSummary"
                     [ test "should compute default distances" <|
                         \_ ->
-                            tShirtCotonFrance Impact.defaultTrigram
+                            tShirtCotonFrance
                                 |> LifeCycle.fromQuery db
                                 |> Result.andThen (LifeCycle.computeStepsTransport db)
                                 |> Result.map (LifeCycle.computeTotalTransports db)
@@ -42,7 +42,7 @@ suite =
                         \_ ->
                             let
                                 query =
-                                    tShirtCotonFrance Impact.defaultTrigram
+                                    tShirtCotonFrance
                             in
                             LifeCycle.fromQuery db
                                 { query

--- a/tests/Data/SimulatorTest.elm
+++ b/tests/Data/SimulatorTest.elm
@@ -6,7 +6,6 @@ import Data.Inputs as Inputs exposing (..)
 import Data.Sample as Sample
 import Data.Simulator as Simulator
 import Data.Unit as Unit
-import Dict.Any as AnyDict
 import Expect exposing (Expectation)
 import Route exposing (Route(..))
 import Test exposing (..)
@@ -53,45 +52,13 @@ convertToTests db sectionOrSample =
 
 suite : Test
 suite =
-    case testDb of
-        Ok db ->
-            describe "Data.Simulator"
-                [ describe "compute"
+    describe "Data.Simulator"
+        [ case testDb of
+            Ok db ->
+                describe "compute"
                     (List.map (convertToTests db) Sample.samples)
-                , describe "computeAll"
-                    [ case Simulator.computeAll db (tShirtCotonFrance Impact.defaultTrigram) of
-                        Ok impacts ->
-                            impacts
-                                |> Expect.equal
-                                    ([ ( "acd", 0.04087232487157366 )
-                                     , ( "ccb", 0.0023542122880000006 )
-                                     , ( "ccf", 4.411684570966434 )
-                                     , ( "cch", 4.4140271789664345 )
-                                     , ( "ccl", 0 )
-                                     , ( "fru", 67.54087637525184 )
-                                     , ( "fwe", 0.0003521486305115451 )
-                                     , ( "ior", 5.0240353144037995 )
-                                     , ( "ldu", 148.98128632 )
-                                     , ( "mru", 0.000009440002792840951 )
-                                     , ( "ozd", 3.751134829991774e-7 )
-                                     , ( "pco", 0.015357882059077762 )
-                                     , ( "pma", 7.148316338708138e-7 )
-                                     , ( "swe", 0.024686641632321656 )
-                                     , ( "tre", 0.0979951577206528 )
-                                     ]
-                                        |> List.map (Tuple.mapBoth Impact.trg Unit.impactFromFloat)
-                                        |> AnyDict.fromList Impact.toString
-                                    )
-                                |> asTest "should compute all impacts"
 
-                        Err err ->
-                            test "should compute all impacts" <|
-                                \_ -> Expect.fail <| "Failure: " ++ err
-                    ]
-                ]
-
-        Err error ->
-            describe "Data.Simulator"
-                [ test "should load test database" <|
+            Err error ->
+                test "should load test database" <|
                     \_ -> Expect.fail <| "Couldn't parse test database: " ++ error
-                ]
+        ]

--- a/tests/Data/SimulatorTest.elm
+++ b/tests/Data/SimulatorTest.elm
@@ -17,13 +17,13 @@ asTest label =
     always >> test label
 
 
-expectImpact : Db -> Float -> Inputs.Query -> Expectation
-expectImpact db cch query =
+expectImpact : Db -> Impact.Trigram -> Float -> Inputs.Query -> Expectation
+expectImpact db trigram cch query =
     case Simulator.compute db query of
         Ok simulator ->
             simulator.impacts
                 -- FIXME: avoid relying on query.impact here
-                |> Impact.getImpact query.impact
+                |> Impact.getImpact trigram
                 |> Unit.impactToFloat
                 |> Expect.within (Expect.Absolute 0.01) cch
 
@@ -40,12 +40,10 @@ convertToTests db sectionOrSample =
         Sample.Sample title { query, cch, fwe } ->
             describe title
                 [ query
-                    |> setQueryImpact (Impact.trg "cch")
-                    |> expectImpact db (Unit.impactToFloat cch)
+                    |> expectImpact db (Impact.trg "cch") (Unit.impactToFloat cch)
                     |> asTest "climate change"
                 , query
-                    |> setQueryImpact (Impact.trg "fwe")
-                    |> expectImpact db (Unit.impactToFloat fwe)
+                    |> expectImpact db (Impact.trg "fwe") (Unit.impactToFloat fwe)
                     |> asTest "freshwater eutrophication"
                 ]
 

--- a/tests/Data/SimulatorTest.elm
+++ b/tests/Data/SimulatorTest.elm
@@ -22,7 +22,9 @@ expectImpact : Db -> Float -> Inputs.Query -> Expectation
 expectImpact db cch query =
     case Simulator.compute db query of
         Ok simulator ->
-            simulator.impact
+            simulator.impacts
+                -- FIXME: avoid relying on query.impact here
+                |> Impact.getImpact query.impact
                 |> Unit.impactToFloat
                 |> Expect.within (Expect.Absolute 0.01) cch
 

--- a/tests/Data/SimulatorTest.elm
+++ b/tests/Data/SimulatorTest.elm
@@ -22,7 +22,6 @@ expectImpact db trigram cch query =
     case Simulator.compute db query of
         Ok simulator ->
             simulator.impacts
-                -- FIXME: avoid relying on query.impact here
                 |> Impact.getImpact trigram
                 |> Unit.impactToFloat
                 |> Expect.within (Expect.Absolute 0.01) cch

--- a/tests/Data/TransportTest.elm
+++ b/tests/Data/TransportTest.elm
@@ -1,10 +1,10 @@
 module Data.TransportTest exposing (..)
 
 import Data.Country as Country
+import Data.Impact as Impact exposing (Impacts)
 import Data.Transport as Transport exposing (Transport)
 import Expect
 import Length
-import Quantity
 import Test exposing (..)
 import TestDb exposing (testDb)
 
@@ -13,12 +13,12 @@ km =
     Length.kilometers
 
 
-franceChina : Transport
-franceChina =
+franceChina : Impacts -> Transport
+franceChina impacts =
     { road = km 0
     , sea = km 21548
     , air = km 8200
-    , impact = Quantity.zero
+    , impacts = impacts
     }
 
 
@@ -26,23 +26,28 @@ suite : Test
 suite =
     case testDb of
         Ok db ->
+            let
+                defaultImpacts =
+                    Impact.impactsFromDefinitons db.impacts
+            in
             describe "Data.Transport"
                 [ describe "getTransportBetween"
                     [ test "should retrieve distance between two countries" <|
                         \_ ->
                             db.transports
-                                |> Transport.getTransportBetween (Country.Code "FR") (Country.Code "CN")
-                                |> Expect.equal franceChina
+                                |> Transport.getTransportBetween defaultImpacts (Country.Code "FR") (Country.Code "CN")
+                                |> Expect.equal (franceChina defaultImpacts)
                     , test "should retrieve distance between two swapped countries" <|
                         \_ ->
                             db.transports
-                                |> Transport.getTransportBetween (Country.Code "CN") (Country.Code "FR")
-                                |> Expect.equal franceChina
+                                |> Transport.getTransportBetween defaultImpacts (Country.Code "CN") (Country.Code "FR")
+                                |> Expect.equal (franceChina defaultImpacts)
                     , test "should apply default inland transport when country is the same" <|
                         \_ ->
                             db.transports
-                                |> Transport.getTransportBetween (Country.Code "FR") (Country.Code "FR")
-                                |> Expect.equal Transport.defaultInland
+                                |> Transport.getTransportBetween defaultImpacts (Country.Code "FR") (Country.Code "FR")
+                                |> Expect.equal
+                                    (Transport.defaultInland defaultImpacts)
                     ]
                 ]
 

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -17,7 +17,7 @@ describe("API server tests", () => {
       expect(response.body.error).toContain("Expecting an OBJECT with a field named `countries`");
     });
 
-    it("should perform a simulation on default impact", async () => {
+    it("should perform a simulation featuring 15 impacts", async () => {
       const response = await request(app)
         .get("/simulator/")
         .query("mass=0.17")
@@ -30,47 +30,7 @@ describe("API server tests", () => {
         .query("countries[]=FR");
 
       expect(response.statusCode).toBe(200);
-      expect(response.body.impact).toBeGreaterThan(0);
-    });
-
-    it("should perform a simulation on specific impact", async () => {
-      const response = await request(app)
-        .get("/simulator/")
-        .query("impact=fwe")
-        .query("mass=0.17")
-        .query("product=13")
-        .query("material=f211bbdb-415c-46fd-be4d-ddf199575b44")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=FR");
-
-      expect(response.statusCode).toBe(200);
-      expect(response.body.impact).toBeGreaterThan(0);
-    });
-  });
-
-  describe("/simulator/all/", () => {
-    it("should validate input params", async () => {
-      const response = await request(app).get("/simulator/all/");
-      expect(response.statusCode).toBe(400);
-      expect(response.body.error).toContain("Expecting an OBJECT with a field named `countries`");
-    });
-
-    it("should retrieve all 15 impacts", async () => {
-      const response = await request(app)
-        .get("/simulator/all/")
-        .query("mass=0.17")
-        .query("product=13")
-        .query("material=f211bbdb-415c-46fd-be4d-ddf199575b44")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=FR");
-      expect(response.statusCode).toBe(200);
-      expect(Object.keys(response.body)).toHaveLength(15);
+      expect(Object.keys(response.body.impacts)).toHaveLength(15);
     });
   });
 });

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -1,10 +1,24 @@
 const request = require("supertest");
 const app = require("../server");
 
+async function sampleSucessfulRequest(path) {
+  return await request(app)
+    .get(path)
+    .query("mass=0.17")
+    .query("product=13")
+    .query("material=f211bbdb-415c-46fd-be4d-ddf199575b44")
+    .query("countries[]=CN")
+    .query("countries[]=CN")
+    .query("countries[]=CN")
+    .query("countries[]=CN")
+    .query("countries[]=FR");
+}
+
 describe("API server tests", () => {
   describe("/", () => {
     it("should render the expected response", async () => {
       const response = await request(app).get("/");
+
       expect(response.statusCode).toBe(200);
       expect(response.body.service).toEqual("Wikicarbone");
     });
@@ -13,21 +27,53 @@ describe("API server tests", () => {
   describe("/simulator/", () => {
     it("should validate input params", async () => {
       const response = await request(app).get("/simulator/");
+
       expect(response.statusCode).toBe(400);
       expect(response.body.error).toContain("Expecting an OBJECT with a field named `countries`");
     });
 
     it("should perform a simulation featuring 15 impacts", async () => {
-      const response = await request(app)
-        .get("/simulator/")
-        .query("mass=0.17")
-        .query("product=13")
-        .query("material=f211bbdb-415c-46fd-be4d-ddf199575b44")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=CN")
-        .query("countries[]=FR");
+      const response = await sampleSucessfulRequest("/simulator/");
+
+      expect(response.statusCode).toBe(200);
+      expect(Object.keys(response.body.impacts)).toHaveLength(15);
+    });
+  });
+
+  describe("/simulator/<impact>/", () => {
+    it("should validate input params", async () => {
+      const response = await request(app).get("/simulator/fwe/");
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error).toContain("Expecting an OBJECT with a field named `countries`");
+    });
+
+    it("should default to cch on unknown impact trigram", async () => {
+      const response = await sampleSucessfulRequest("/simulator/xxx/");
+
+      expect(response.statusCode).toBe(200);
+      expect(Object.keys(response.body.impact)).toEqual(["cch"]);
+    });
+
+    it("should perform a simulation featuring a single impact", async () => {
+      const response = await sampleSucessfulRequest("/simulator/fwe/");
+
+      expect(response.statusCode).toBe(200);
+      expect(Object.keys(response.body.impact)).toEqual(["fwe"]);
+      expect(response.body.impact.fwe).toBeGreaterThan(0);
+    });
+  });
+
+  describe("/simulator/detailed/", () => {
+    it("should validate input params", async () => {
+      const response = await request(app).get("/simulator/detailed/");
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error).toContain("Expecting an OBJECT with a field named `countries`");
+    });
+
+    it("should perform a simulation featuring 15 impacts", async () => {
+      const response = await sampleSucessfulRequest("/simulator/detailed/");
 
       expect(response.statusCode).toBe(200);
       expect(Object.keys(response.body.impacts)).toHaveLength(15);


### PR DESCRIPTION
### TODO

- [x] Update transport to handle multi-impacts
- [x] Refactor unit formatting strategy for multi-impact
- [x] Handle current target impact in the View only
- [x] Expose two data density modes for the simulator API responses: `simple` (default) and `detailed` (current verbose output)

#### Nice to Have

- [x] Validate impact trigrams
- [ ] Retrieve default impact trigram at runtime
- [ ] Add an impact selector to the Examples page
- [ ] Add a changelog to the API page on Gitbook