### PR TITLE
Use the material's default country even when using the API

### DIFF
--- a/public/data/openapi.yaml
+++ b/public/data/openapi.yaml
@@ -185,7 +185,7 @@ components:
     countriesParam:
       name: countries
       in: query
-      description: Liste des codes pays pour chacune des 5 étapes du cycle de vie du produit
+      description: Liste des codes pays pour chacune des 5 étapes du cycle de vie du produit (/!\ ATTENTION, pour le moment, le premier pays n'est pas pris en compte car c'est le pays par défaut de la matière première qui est utilisé pour le calcul)
       required: true
       schema:
         type: string

--- a/public/data/openapi.yaml
+++ b/public/data/openapi.yaml
@@ -185,7 +185,7 @@ components:
     countriesParam:
       name: countries
       in: query
-      description: Liste des codes pays pour chacune des 5 étapes du cycle de vie du produit (/!\ ATTENTION, pour le moment, le premier pays n'est pas pris en compte car c'est le pays par défaut de la matière première qui est utilisé pour le calcul)
+      description: Liste des codes pays pour chacune des 5 étapes du cycle de vie du produit (/!\ ATTENTION, pour le moment, le premier pays n'est pas pris en compte car c'est le [pays par défaut](https://fabrique-numerique.gitbook.io/wikicarbone/methodologie/filature#liste-complete) de la matière première qui est utilisé pour le calcul)
       required: true
       schema:
         type: string

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -11,7 +11,7 @@ import Data.Unit as Unit
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
-import List.Extra
+import List.Extra as LE
 import Mass exposing (Mass)
 import Result.Extra as RE
 import Url.Parser as Parser exposing (Parser)
@@ -123,7 +123,7 @@ updatedCountryList material countriesDB countries =
 
 updateCountryList : Int -> Country.Code -> List Country.Code -> List Country.Code
 updateCountryList index code countryList =
-    List.Extra.setAt index code countryList
+    LE.setAt index code countryList
 
 
 updateStepCountry : Int -> Country.Code -> Query -> Query

--- a/src/Data/Inputs.elm
+++ b/src/Data/Inputs.elm
@@ -116,20 +116,15 @@ updatedCountryList material countriesDB countries =
             (\{ defaultCountry } ->
                 countries
                     -- Update the list of countries: the first country (from the material step) is constrained to be the material's default country
-                    |> updateCountryList 0 defaultCountry
+                    |> LE.setAt 0 defaultCountry
                     |> (\updatedCountries -> Country.findByCodes updatedCountries countriesDB)
             )
-
-
-updateCountryList : Int -> Country.Code -> List Country.Code -> List Country.Code
-updateCountryList index code countryList =
-    LE.setAt index code countryList
 
 
 updateStepCountry : Int -> Country.Code -> Query -> Query
 updateStepCountry index code query =
     { query
-        | countries = updateCountryList index code query.countries
+        | countries = LE.setAt index code query.countries
         , dyeingWeighting =
             -- FIXME: index 2 is Ennoblement step; how could we use th step label instead?
             if index == 2 && Array.get index (Array.fromList query.countries) /= Just code then

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -103,7 +103,7 @@ handleRequest db request =
                 , ( "documentation", Encode.string apiDocUrl )
 
                 -- FIXME: the openapi document should be served by some /openapi API endpoint
-                , ( "openapi", Encode.string "https://wikicarbone.beta.gouv.fr/data/openapi.yaml" )
+                , ( "openapi", Encode.string "/data/openapi.yaml" )
                 ]
                 |> sendResponse 200 request
 

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -1,7 +1,7 @@
 module Data.InputsTest exposing (..)
 
 import Data.Country as Country
-import Data.Inputs as Inputs
+import Data.Inputs as Inputs exposing (tShirtCotonAsie)
 import Expect exposing (Expectation)
 import List.Extra as LE
 import Test exposing (..)
@@ -38,19 +38,9 @@ suite =
                         |> asTest "should base64 encode and decode a query"
                     ]
                 , describe "A list of countries with a first country different than the material's default country"
-                    [ Inputs.tShirtCotonAsie
-                        |> (\query ->
-                                let
-                                    badCountries =
-                                        query.countries
-                                            |> LE.setAt 0 (Country.codeFromString "FR")
-                                in
-                                { query | countries = badCountries }
-                           )
+                    [ { tShirtCotonAsie | countries = List.map Country.Code [ "FR", "CN", "CN", "CN", "FR" ] }
                         |> Inputs.fromQuery db
-                        |> Result.map Inputs.toQuery
-                        |> Result.map .countries
-                        |> Result.andThen (List.head >> Result.fromMaybe "Couldn't get the first country from the list")
+                        |> Result.andThen (.countries >> LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
                         |> Expect.equal (Ok (Country.codeFromString "CN"))
                         |> asTest "should replace the first country with the material's default country"
                     ]

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -1,7 +1,9 @@
 module Data.InputsTest exposing (..)
 
+import Data.Country as Country
 import Data.Inputs as Inputs
 import Expect exposing (Expectation)
+import List.Extra as LE
 import Test exposing (..)
 import TestDb exposing (testDb)
 
@@ -34,6 +36,22 @@ suite =
                         |> Inputs.b64decode
                         |> Expect.equal (Ok sampleQuery)
                         |> asTest "should base64 encode and decode a query"
+                    ]
+                , describe "A list of countries with a first country different than the material's default country"
+                    [ Inputs.tShirtCotonAsie
+                        |> (\query ->
+                                let
+                                    badCountries =
+                                        query.countries
+                                            |> LE.setAt 0 (Country.codeFromString "FR")
+                                in
+                                { query | countries = badCountries }
+                           )
+                        |> Inputs.fromQuery db
+                        |> Result.map .countries
+                        |> Result.andThen (List.head >> Result.fromMaybe "Couldn't get the first country from the list")
+                        |> Expect.equal (Country.findByCode (Country.codeFromString "CN") db.countries)
+                        |> asTest "should replace the first country with the material's default country"
                     ]
                 ]
 

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -48,9 +48,10 @@ suite =
                                 { query | countries = badCountries }
                            )
                         |> Inputs.fromQuery db
+                        |> Result.map Inputs.toQuery
                         |> Result.map .countries
                         |> Result.andThen (List.head >> Result.fromMaybe "Couldn't get the first country from the list")
-                        |> Expect.equal (Country.findByCode (Country.codeFromString "CN") db.countries)
+                        |> Expect.equal (Ok (Country.codeFromString "CN"))
                         |> asTest "should replace the first country with the material's default country"
                     ]
                 ]

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -44,6 +44,13 @@ suite =
                         |> Expect.equal (Ok (Country.codeFromString "CN"))
                         |> asTest "should replace the first country with the material's default country"
                     ]
+                , describe "Validate country"
+                    [ { tShirtCotonAsie | countries = List.map Country.Code [ "FR", "XX", "CN", "CN", "FR" ] }
+                        |> Inputs.fromQuery db
+                        |> Result.andThen (.countries >> LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
+                        |> Expect.equal (Err "Code pays invalide: XX")
+                        |> asTest "should replace the first country with the material's default country"
+                    ]
                 ]
 
         Err error ->

--- a/tests/Data/InputsTest.elm
+++ b/tests/Data/InputsTest.elm
@@ -23,33 +23,32 @@ suite =
     case testDb of
         Ok db ->
             describe "Data.Inputs"
-                [ describe "Encoding and decoding queries"
-                    [ sampleQuery
-                        |> Inputs.fromQuery db
-                        |> Result.map Inputs.toQuery
-                        |> Expect.equal (Ok sampleQuery)
-                        |> asTest "should encode and decode a query"
+                [ describe "Base64"
+                    [ describe "Encoding and decoding queries"
+                        [ sampleQuery
+                            |> Inputs.fromQuery db
+                            |> Result.map Inputs.toQuery
+                            |> Expect.equal (Ok sampleQuery)
+                            |> asTest "should encode and decode a query"
+                        ]
+                    , describe "Base64 encoding and decoding queries"
+                        [ sampleQuery
+                            |> Inputs.b64encode
+                            |> Inputs.b64decode
+                            |> Expect.equal (Ok sampleQuery)
+                            |> asTest "should base64 encode and decode a query"
+                        ]
                     ]
-                , describe "Base64 encoding and decoding queries"
-                    [ sampleQuery
-                        |> Inputs.b64encode
-                        |> Inputs.b64decode
-                        |> Expect.equal (Ok sampleQuery)
-                        |> asTest "should base64 encode and decode a query"
-                    ]
-                , describe "A list of countries with a first country different than the material's default country"
+                , describe "Query countries validation"
                     [ { tShirtCotonAsie | countries = List.map Country.Code [ "FR", "CN", "CN", "CN", "FR" ] }
                         |> Inputs.fromQuery db
                         |> Result.andThen (.countries >> LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
                         |> Expect.equal (Ok (Country.codeFromString "CN"))
                         |> asTest "should replace the first country with the material's default country"
-                    ]
-                , describe "Validate country"
-                    [ { tShirtCotonAsie | countries = List.map Country.Code [ "FR", "XX", "CN", "CN", "FR" ] }
+                    , { tShirtCotonAsie | countries = List.map Country.Code [ "FR", "XX", "CN", "CN", "FR" ] }
                         |> Inputs.fromQuery db
-                        |> Result.andThen (.countries >> LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
                         |> Expect.equal (Err "Code pays invalide: XX")
-                        |> asTest "should replace the first country with the material's default country"
+                        |> asTest "should validate country codes"
                     ]
                 ]
 


### PR DESCRIPTION
In the UI, the first step's country is constrained by the material used: it's always going to be the material's default country.
This also needs to be the case when going through the API, as changing the country would lead to incorrect results (the data for the weaving and knitting is only provided for a single country for a given material).