### PR TITLE
Fix .proxyrc behavior after parcel upgrade to 2.3.1.

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -1,9 +1,0 @@
-const { createProxyMiddleware } = require("http-proxy-middleware");
-
-module.exports = function (app) {
-  app.use(
-    createProxyMiddleware("/api", {
-      target: "http://localhost:3000/",
-    }),
-  );
-};

--- a/.proxyrc.json
+++ b/.proxyrc.json
@@ -1,0 +1,5 @@
+{
+  "/api": {
+    "target": "http://localhost:3000/"
+  }
+}


### PR DESCRIPTION
After upgrading Parcel to 2.3.1 (before: 2.2.1), local dev API server proxy stopped working for obscure reasons. Switching to using a `.proxyrc.json` instead of a `.proxyrc.js` one using the very same configuration solves the issue.