### PR TITLE
Drop documentation modals.

### DIFF
--- a/src/Views/Button.elm
+++ b/src/Views/Button.elm
@@ -1,7 +1,9 @@
 module Views.Button exposing
     ( docsPill
+    , docsPillLink
     , pillClasses
     , smallPill
+    , smallPillLink
     )
 
 import Html exposing (..)
@@ -13,13 +15,31 @@ pillClasses =
     "d-inline-flex align-items-center btn btn-sm gap-1 rounded-pill"
 
 
+smallPillClasses : String
+smallPillClasses =
+    pillClasses ++ " text-secondary text-decoration-none btn-link p-0 ms-1"
+
+
 smallPill : List (Attribute msg) -> List (Html msg) -> Html msg
 smallPill attrs =
-    button
-        ([ class <| pillClasses ++ " text-secondary text-decoration-none btn-link p-0 ms-1" ] ++ attrs)
+    button ([ class smallPillClasses ] ++ attrs)
+
+
+smallPillLink : List (Attribute msg) -> List (Html msg) -> Html msg
+smallPillLink attrs =
+    a ([ class smallPillClasses ] ++ attrs)
+
+
+docsPillClasses : String
+docsPillClasses =
+    pillClasses ++ " btn-primary fs-7 py-0"
 
 
 docsPill : List (Attribute msg) -> List (Html msg) -> Html msg
 docsPill attrs =
-    button
-        ([ class <| pillClasses ++ " btn-primary fs-7 py-0" ] ++ attrs)
+    button ([ class docsPillClasses ] ++ attrs)
+
+
+docsPillLink : List (Attribute msg) -> List (Html msg) -> Html msg
+docsPillLink attrs =
+    a ([ class docsPillClasses ] ++ attrs)

--- a/src/Views/Step.elm
+++ b/src/Views/Step.elm
@@ -31,7 +31,6 @@ type alias Config msg =
     , index : Int
     , current : Step
     , next : Maybe Step
-    , openDocModal : Gitbook.Path -> msg
     , updateCountry : Int -> Country.Code -> msg
     , updateDyeingWeighting : Maybe Unit.Ratio -> msg
     , updateQuality : Maybe Unit.Quality -> msg
@@ -180,16 +179,20 @@ qualityField { current, updateQuality } =
 
 
 inlineDocumentationLink : Config msg -> Gitbook.Path -> Html msg
-inlineDocumentationLink { openDocModal } path =
-    Button.smallPill
-        [ onClick (openDocModal path) ]
+inlineDocumentationLink _ path =
+    Button.smallPillLink
+        [ href (Gitbook.publicUrlFromPath path)
+        , target "_blank"
+        ]
         [ Icon.question ]
 
 
 stepDocumentationLink : Config msg -> Step.Label -> Html msg
-stepDocumentationLink { openDocModal } label =
-    Button.docsPill
-        [ onClick (openDocModal (Step.getStepGitbookPath label)) ]
+stepDocumentationLink _ label =
+    Button.docsPillLink
+        [ href (Gitbook.publicUrlFromPath (Step.getStepGitbookPath label))
+        , target "_blank"
+        ]
         [ Icon.question, text "docs" ]
 
 


### PR DESCRIPTION
The Gitbook Markdown custom syntax is way too cumbersome to parse, I'm switching all documentation modals to plain old links.